### PR TITLE
update yum repo module to include gpgkey

### DIFF
--- a/roles/vrs-predeploy/tasks/main.yml
+++ b/roles/vrs-predeploy/tasks/main.yml
@@ -9,7 +9,7 @@
     name: epel
     description: EPEL YUM repo
     baseurl: http://download.fedoraproject.org/pub/epel/$releasever/$basearch/
-    gpgkey: http://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7
+    gpgkey: http://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-$releasever
   when: ansible_os_family == "RedHat"
 
 - name: Upgrade all packages on RedHat OS family distros


### PR DESCRIPTION
It was noticed with stock centos image with yum repo gpg check enabled, yum updates fail during vrs redeploy. This update will add gpgkey to the yum repo ansible module based on centos version.