### PR TITLE
add vrs_os_type to CI build.yml.all.j2 template

### DIFF
--- a/test/files/build.yml.all.j2
+++ b/test/files/build.yml.all.j2
@@ -56,7 +56,8 @@
           vsc_static_route_list: { 0.0.0.0/1 } }
     dockermon_install: true
     myvrss:
-      - { vrs_ip_list: [{{ target_server }}],
+      - { vrs_os_type: el7,
+          vrs_ip_list: [{{ target_server }}],
           active_controller_ip: {{ network_address }}.212,
           standby_controller_ip: {{ network_address }}.213 }
     myvstats:


### PR DESCRIPTION
I believe I am missing vrs_os_type in CI build.yml template and the reason for OS Jenkins job failure.