### PR TITLE
adding license string path to CI zfb.yml

### DIFF
--- a/test/files/zfb.yml.j2
+++ b/test/files/zfb.yml.j2
@@ -1,5 +1,5 @@
 # VSD license
-vsd_license_file: "/home/caso/metro/license/vsd.lic"
+vsd_license_file: "/home/caso/nuage-jenkins/license/vsd.lic"
 # Organization 
 organization:
   name: metro-test


### PR DESCRIPTION
@bacastelli 
The license path was not added to zfb.yml in test/files/zfb.yml.j2 file.
This resulted in failure of the build