### PR TITLE
Minor documentation fix in Build.md

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -228,7 +228,7 @@ For reference, here is a description of the contents of the `build-vars.yml` fil
 #    images_path: "/var/lib/libvirt/images/"
 #    # NTP servers the VSC, VSD, VNS-UTILITY and VSTAT should sync to.
 #    # One or more ntp servers are required
-#    # Please note: the NTP servers need to be in dotted decimal format (as below). 
+#    # Please note: the NTP servers need to be specified in dotted decimal format (as below). 
 #    ntp_server_list:
 #      - 135.227.181.232
 #      - 128.138.141.172


### PR DESCRIPTION
I specified FQDN for NTP servers, this works fine for the Linux components but fails on VSC, just add a small comment to clarify.