### PR TITLE
Add netmiko session closing

### DIFF
--- a/roles/vns-deploy/files/vsc_config.py
+++ b/roles/vns-deploy/files/vsc_config.py
@@ -179,6 +179,7 @@ def exec_command(vsc, command):
                .format(command, sys.exc_info()[0]))
         sys.exit(1)
 
+    net_connect.disconnect()    
     return output
 
 


### PR DESCRIPTION
It seems without closing the netmiko sessions, we can exhaust the number of ssh sessions to the vsc. I noticed this in new Jenkins setup with 5 commands being sent to the vsc. I am unable to figure where the ssh session limit comes from such as having different netmiko/paramiko versions or max sssh sessions in openssh. But I think closing the session is a best practice.