### PR TITLE
Add back logic to remove u16_04 vrs configs for 4.04R4 and 3.2R10

### DIFF
--- a/test/scripts/deploy_ci.sh
+++ b/test/scripts/deploy_ci.sh
@@ -19,6 +19,13 @@ cp ./test/files/setup.yml.CI setup.yml
 ansible-playbook setup.yml -vvvv
 ansible-playbook reset_build.yml -vvvv
 ansible-playbook build.yml -vvvv
+
+if [ $1 = 4.0R4 ] || [ $1 = 3.2R10 ];
+then
+    sed -i  '/- { hostname: {{ vrs_u16_target_server_name }},/,/ci_flavor: jenkins }/ d' test/files/build_vars_all.yml
+    sed -i '/- { vrs_os_type: u16.04,/,/standby_controller_ip: {{ network_address }}.213 }/d' test/files/build_vars_all.yml
+fi
+
 ./metro-ansible ci_predeploy.yml -vvvv
 ./metro-ansible ci_deploy.yml -vvvv
 


### PR DESCRIPTION
This will prevent 4.0R4 and 3.2R10 Jenkins job from looking for ubuntu 16.04 vrs images etc..Looks like we renamed the files and forgot to add this back in commit 234a7aa6bcc6ccd7684f0ff45ed778af85bc2ba1