### PR TITLE
uncomment vrs destroy in destroy_everything

### DIFF
--- a/destroy_everything.yml
+++ b/destroy_everything.yml
@@ -5,4 +5,4 @@
 - include: vcin_destroy.yml
 - include: vnsutil_destroy.yml
 - include: nsgv_destroy.yml
-#- include: vrs_destroy.yml
+- include: vrs_destroy.yml


### PR DESCRIPTION
we are not cleaning up vrs components on bare metal Jenkins jobs as vrs destroy play is commented out in destroy_everything.