### PR TITLE
Support to pass variable name for build_vars.yml

### DIFF
--- a/build.yml
+++ b/build.yml
@@ -1,7 +1,10 @@
 ---
 - hosts: localhost
-  vars_files:
-    - build_vars.yml
+
+  pre_tasks:
+    - debug: var=build_vars_file
+    - name: Include build variable files
+      include_vars: "{{ build_vars_file | default ('build_vars.yml') }}"
   roles:
     - nuage-predeploy
     - validate-build-vars

--- a/roles/build/templates/group_vars.all.j2
+++ b/roles/build/templates/group_vars.all.j2
@@ -13,15 +13,22 @@ data_bridge: {{ data_bridge | default('NONE') }}
 access_bridge: {{ access_bridge | default('NONE') }}
 images_path: {{ images_path | default('NONE') }}
 ansible_deployment_host: {{ ansible_deployment_host }}
+
+{% if ntp_server_list  is defined %}
 ntp_server_list:
 {% for server in ntp_server_list %}
   - {{ server }}
 {% endfor %}
+{% endif %}
+
+{% if dns_server_list  is defined %}
 dns_server_list:
 {% for server in dns_server_list %}
   - {{ server }}
 {% endfor %}
-dns_domain: {{ dns_domain }}
+{% endif %}
+
+dns_domain: {{ dns_domain | default('localdomain') }}
 timezone: {{ timezone | default('US/Pacific') }}
 yum_proxy: "{{ yum_proxy | default('NONE') }}"
 yum_update: {{ yum_update | default(True) }}


### PR DESCRIPTION
With this, you don't have to change the default build_vars.yml file, but can pass a parameter on CLI pointing to your own variable file that is not versioned in git.
Example:
    `ansible-playbook build.yml --extra-vars "build_vars_file=examples/build_vars.yml.nsg_ami"`

When this extra CLI variable name is not passed, the default build_vars.yml is used.


Also had to enhance slightly the `build_helper` template for group variables to allow for empty NTP and DNS entries.



