### PR TITLE
update ntp conf to fix ubuntu 16 slow ntp sync

### DIFF
--- a/roles/ci-deploy/templates/ntp.conf.j2
+++ b/roles/ci-deploy/templates/ntp.conf.j2
@@ -20,8 +20,8 @@ restrict {{ network_address }}.0 mask 255.255.255.0 nomodify notrap
 # Use public servers from the pool.ntp.org project.
 # Please consider joining the pool (http://www.pool.ntp.org/join.html).
 
-# As a lost resort use localhost
-server 127.127.1.0
+# As a last resort use localhost
+server 127.127.1.0 prefer
 fudge 127.127.1.0 stratum 2
 
 broadcast {{ network_address }}.255


### PR DESCRIPTION
This may cause ubuntu 16 CI servers/vrs to fail due to ntp sync is outside of the retry limit,
https://bugs.launchpad.net/ubuntu/+source/ntp/+bug/1558125