### PR TITLE
add acpi feature to enable live iface manipulations

### DIFF
--- a/roles/nsgv-predeploy/templates/nsgv.xml.j2
+++ b/roles/nsgv-predeploy/templates/nsgv.xml.j2
@@ -15,6 +15,7 @@
   </sysinfo>
   <features>
     <apic/>
+    <acpi/>
   </features>
   <cpu>
     <topology sockets='1' cores='1' threads='1'/>


### PR DESCRIPTION
It is needed to add `acpi` feature to NSGV template to enable shutdown/reboot signals and live detach/attach of network interfaces.
Without this feature one cant do a live detach/attach procedure as demonstrated below:
```
[root@server1 ~]# virsh domiflist NSGV_BRANCH_2
Interface  Type       Source     Model       MAC
-------------------------------------------------------
vnet24     bridge     br12       virtio      52:54:00:bd:10:86
vnet25     bridge     br10       virtio      52:54:00:eb:ea:2d
vnet26     bridge     br1nsg21   virtio      52:54:00:3b:b8:59

[root@server1 ~]# virsh detach-interface NSGV_BRANCH_2 bridge --mac 52:54:00:eb:ea:2d --config --live
error: Failed to detach interface
error: internal error: unable to execute QEMU command 'device_del': Bus 'pci.0' does not support hotplugging
```

Once `acpi` is added, it becomes possible:
```
[root@server1 ~]# virsh dumpxml NSGV_BRANCH_2 | grep acpi
    <acpi/>


[root@server1 ~]# virsh detach-interface NSGV_BRANCH_2 bridge --mac 52:54:00:bd:10:86 --config --live
Interface detached successfully
```