### PR TITLE
Update to accomodate VSD 5.0.1 changes to ssh

### DIFF
--- a/roles/vsd-deploy/tasks/main.yml
+++ b/roles/vsd-deploy/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - include: non_heat.yml
-  when: ("{{ target_server_type }}" != "heat") and ("{{ target_server_type }}" != "vcenter")
+  when: ("{{ target_server_type }}" != "heat")
   tags:
     - vsd
     - vsd-deploy


### PR DESCRIPTION
1) Vcenter install now run only when target_server_type is vcenter

2) Update VSD deploy (both non heat and vcenter) to check if the VSD deployed in pre deploy is on version 5 or later. If 5 or later only copy the vsd user ssh keys between the VSDs. If version is lesser than 5, copy the root user keys among them.