### PR TITLE
Add firewalld service start to vstat deploy

### DIFF
--- a/roles/vstat-deploy/tasks/non_heat.yml
+++ b/roles/vstat-deploy/tasks/non_heat.yml
@@ -141,6 +141,18 @@
     when: ip_addr.stdout == "not found:"
   when: vsd_sa_or_ha == 'sa'
 
+- name: Start firewalld
+  systemd:
+    name: firewalld
+    state: started
+  remote_user: "root"
+
+- name: Enable firewalld on boot
+  systemd:
+    name: firewalld
+    enabled: yes
+  remote_user: "root"
+
 - name: Create firewall vars file on ansible host
   template: src="{{ playbook_dir }}/roles/vstat-deploy/templates/firewall.j2" dest="{{ playbook_dir }}/roles/vstat-deploy/vars/main.yml" backup=no mode=0755
   delegate_to: "{{ ansible_deployment_host }}"


### PR DESCRIPTION
Jenkins jobs on OS are failing for 5.0.1 due to firewalld not running. Adding firewalld start and enable just to make sure service is running.