### PR TITLE
Add VSD pre upgrade role to handle VSD license check during major upgrades

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,8 @@ v2.1.2
 ## New features
 1. Added VSD/VSC rollback for clustered VSD upgrades on KVM platform.
 1. Added support for Standalone and Clustered VSTAT upgrade
+1. Added support for deployments and upgrades to 5.0.x covering changes introduced in VSD 5.0.1 related to new VSD user
+1. Added VSD license validation for upgrades across major versions (ex. 4.0.x to 5.0.1)
  
 ## Usage Notes
 1. Added new variable ansible_sudo_user_pub_key in to upgrade_vars.yml. This is required for VSD file copy operations during upgrades. 
@@ -27,3 +29,4 @@ v2.1.2
 1. No support for release specific commands to stop elastic search/vstat process on vsd.
 1. No support for release specific commands to stop core process on vsd.
 1. Nuage Metro will not run on el6 (e.g. CentOS 6.8) hosts due to a lack of modern python-jinja2 support.
+1. VSC disconnect from VSD prior 5.0.1 upgrade is not yet implemented

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -54,7 +54,8 @@ Upgrade vrs(s) manually
 4. Workflow for VSP upgrade with clustered VSD (upgrade to 5.x)
 
 A VSP upgrade to VSP 5.0.1 does not support incremental upgrade. Those upgrade paths are targeted for any deployments where downtime on operations and traffic loss is tolerated during the upgrade.
-The following is the workflow to acheive clustered vsp upgrade using above set of playbooks
+The following is the workflow to acheive clustered vsp upgrade using above set of playbooks. Note that the upgrade will pause if the existing licenses are invalid after the upgrade. Once new license 
+are ready, hitting enter will continue the upgrade.
 
 ```
 ./metro-ansible vsd_ha_major_upgrade.yml

--- a/library/check_vsd_license_validity.py
+++ b/library/check_vsd_license_validity.py
@@ -1,0 +1,75 @@
+#!/usr/bin/python
+
+from ansible.module_utils.basic import AnsibleModule
+try:
+    from vspk.v4_0 import NUVSDSession
+    HAS_VSPK = True
+except ImportError:
+    HAS_VSPK = False
+
+DOCUMENTATION = '''
+---
+module: check_vsd_license_validity
+short_description: Check VSD License additional_supported_versions object to validate license across upgrades
+options:
+  vsd_auth:
+    description:
+      - VSD credentials to access VSD GUI
+    required: true
+    default: null
+'''
+
+EXAMPLES = '''
+# Check if new license are required after the upgrade
+- check_vsd_license_validity:
+    vsd_auth:
+      username: csproot
+      password: csproot
+      enterprise: csp
+      api_url: https://10.0.0.10:8443
+    state: enabled
+'''
+
+
+def check_license_mode(csproot):
+    valid = True
+    license_list = []
+
+    try:
+        license_list = csproot.licenses.get()
+        for lic in license_list:
+            if lic.additional_supported_versions == 0:
+                valid = False
+    except Exception as e:
+        module.fail_json(msg="Could not retrieve license mode : %s" % e)
+    module.exit_json(changed=False, result="%s" % valid)
+
+
+def get_vsd_session(vsd_auth):
+    try:
+        session = NUVSDSession(**vsd_auth)
+        session.start()
+        csproot = session.user
+        return csproot
+    except Exception as e:
+        module.fail_json(msg="Could not establish connection to VSD %s" % e)
+
+
+arg_spec = dict(vsd_auth=dict(required=True, type='dict'))
+module = AnsibleModule(argument_spec=arg_spec, supports_check_mode=True)
+
+
+def main():
+    if not HAS_VSPK:
+            module.fail_json(msg='vspk is required for this module')
+
+    vsd_auth = module.params['vsd_auth']
+
+    csproot = get_vsd_session(vsd_auth)
+    check_license_mode(csproot)
+
+
+# Run the main
+
+if __name__ == '__main__':
+    main()

--- a/roles/vsd-preupgrade/tasks/main.yml
+++ b/roles/vsd-preupgrade/tasks/main.yml
@@ -1,0 +1,21 @@
+- block:
+  - name: Clean known_hosts of VSD's on "{{ target_server }}"
+    command: ssh-keygen -R "{{ mgmt_ip }}" -f /root/.ssh/known_hosts
+    delegate_to: "{{ ansible_deployment_host }}"
+    remote_user: "{{ ansible_sudo_username }}"
+  
+  - name: Check VSD License additionalsupportedversions
+    check_vsd_license_validity:
+      vsd_auth:
+        "{{ vsd_auth }}"
+    register: license_valid 
+    delegate_to: "{{ ansible_deployment_host }}"
+    remote_user: "{{ ansible_sudo_username }}"
+  
+  - debug: var=license_valid verbosity=1
+  
+  - block:
+    - pause:
+        prompt: "Make sure you have valid license file for the new VSP version as existing licenses will be invalid after the upgrade"
+    when: not license_valid
+  when: upgrade_major_or_minor == 'major'

--- a/vsd_ha_major_upgrade.yml
+++ b/vsd_ha_major_upgrade.yml
@@ -1,6 +1,10 @@
 ---
-#TODO - check for proper licenses upgrading to 5.x
 #TODO - shutdown xmpp on vsc before the upgrade
+- hosts: vsds
+  gather_facts: no
+  roles:
+    - vsd-preupgrade
+
 - hosts: vsds
   gather_facts: no
   any_errors_fatal: true

--- a/vsd_sa_upgrade.yml
+++ b/vsd_sa_upgrade.yml
@@ -1,5 +1,10 @@
 ---
 - hosts: vsds
+  gather_facts: no
+  roles:
+    - vsd-preupgrade
+
+- hosts: vsds
   any_errors_fatal: true
   gather_facts: no
   vars:


### PR DESCRIPTION
Created a new role vsd-preupgrade as there are more and more prep works are added to upgrade process. This PR adds checking the VSD licenses validity after upgrade to 5.0.1. I think this will be the same process for going from one major VSD version to another. 

Per docs " When upgrading to a new major version (from VSP 3.2 to VSP 4.0, or from VSP 4.0 to VSP 5.0), check that all the active license attributes additionalSupportedVersions (readable via the VSD API for the license). If this field value is “0”, the license is invalid after an upgrade to a different major version and a new license must be requested. If this value is greater than 1, you can re-use the same license across major versions, up to the number of licenses indicated by the additionalsupportedversions."

This PR adds a new sensible custom module that checks if above VSP object is set to 0 (invalid) , otherwise valid. Testing the license with above variable set to 0 is difficult. All common licenses use for testing have a value of 999 and cannot be changed after install. I could not get the license generator to create a custom license. Python custom module file is flake8 tested.

New VSD-preupgrade role is added to both SA upgrade and major_ha upgrade playbooks and only get executed if the upgrade_major_or_minor is set to major inside upgrade_vars.yml.

Also updated Release notes and upgrade MD files to add deployment/upgrade support for 5.0.1.