### PR TITLE
Update CI jobs to use new VSC IP addresses

### DIFF
--- a/test/scripts/deploy_ci.sh
+++ b/test/scripts/deploy_ci.sh
@@ -34,7 +34,7 @@ ansible-playbook build.yml -vvvv
 if [ $1 = 4.0.R4 ] || [ $1 = 3.2.R10 ];
 then
     sed -i  '/- { hostname: {{ vrs_u16_target_server_name }},/,/ci_flavor: jenkins }/ d' test/files/build_vars.yml.all.j2
-    sed -i '/- { vrs_os_type: u16.04,/,/standby_controller_ip: {{ network_address }}.213 }/d' test/files/build_vars.yml.all.j2
+    sed -i '/- { vrs_os_type: u16.04,/,/standby_controller_ip: {{ network_address }}.215 }/d' test/files/build_vars.yml.all.j2
 fi
 
 ./metro-ansible ci_predeploy.yml -vvvv


### PR DESCRIPTION
during CI deploy jobs we create 3 VRS types, centos7, ubuntu 14 and ubuntu 16. However VSP versions below 4.04 do not support ubuntu 16 VRSs. Therefore we should remove ubuntu 16 related configs from MyCIS and MYVRS sections from build_vars during CI job executions. example
mycis:
  - { hostname: {{ vrs_u16_target_server_name }},
      target_server_type: "heat",
      ci_image: ci-ubuntu16,
      ci_flavor: jenkins }

myvrss:
  - { vrs_os_type: u16.04,
      vrs_ip_list: [{{ vrs_u16_target_server | default("0.0.0.0") }}],
      active_controller_ip: {{ network_address }}.214,
      standby_controller_ip: {{ network_address }}.215 }

This is done with removing corresponding lines from build_vars using sed inside deploy_ci.sh
then
    sed -i  '/- { hostname: {{ vrs_u16_target_server_name }},/,/ci_flavor: jenkins }/ d' test/files/build_vars.yml.all.j2
    sed -I '/- { vrs_os_type: u16.04,/,/standby_controller_ip: {{ network_address }}.215 }/d' test/files/build_vars.yml.all.j2
fi


We were using .212 and .213 as VSC IP addresses before and now they are .214 and .215. Tested with Jenkins job, http://135.227.181.74:8080/job/wasantha_3.2R10/84/console
