### PR TITLE
Fix starting of libvirtd when freshly installed

### DIFF
--- a/roles/vsc-predeploy/tasks/kvm.yml
+++ b/roles/vsc-predeploy/tasks/kvm.yml
@@ -21,17 +21,24 @@
   when: ("{{ mgmt_bridge }}" not in ansible_interfaces) or
         ("{{ data_bridge }}" not in ansible_interfaces)
 
-- name: Install packages for RedHat OS family distros
-  remote_user: "{{ target_server_username }}"
-  delegate_to: "{{ target_server }}"
-  yum: name={{ item }} state=present
-  with_items:
-   - qemu-kvm
-   - libvirt
-   - bridge-utils
-   - libguestfs-tools
-   - libvirt-python
+- block:
+  - name: If RedHat, install packages for RedHat OS family distros
+    yum: name={{ item }} state=present
+    with_items:
+     - qemu-kvm
+     - libvirt
+     - bridge-utils
+     - libguestfs-tools
+     - libvirt-python
+
+  - service:
+    name: libvirtd
+    enabled: yes
+    state: started
+
   when: ansible_os_family == "RedHat"
+  delegate_to: "{{ target_server }}"
+  remote_user: "{{ target_server_username }}"
 
 - name: Install packages for Debian OS family distros
   remote_user: "{{ target_server_username }}"

--- a/roles/vsd-predeploy/tasks/kvm.yml
+++ b/roles/vsd-predeploy/tasks/kvm.yml
@@ -23,14 +23,21 @@
   fail: msg="Required network bridges not found"
   when: ("{{ mgmt_bridge }}" not in ansible_interfaces)
 
-- name: If RedHat, install packages for RedHat OS family distros
-  yum: name={{ item }} state=present
-  with_items:
-   - qemu-kvm
-   - libvirt
-   - bridge-utils
-   - libguestfs-tools
-   - libvirt-python
+- block:
+  - name: If RedHat, install packages for RedHat OS family distros
+    yum: name={{ item }} state=present
+    with_items:
+     - qemu-kvm
+     - libvirt
+     - bridge-utils
+     - libguestfs-tools
+     - libvirt-python
+
+  - service:
+    name: libvirtd
+    enabled: yes
+    state: started
+
   when: ansible_os_family == "RedHat"
   delegate_to: "{{ target_server }}"
   remote_user: "{{ target_server_username }}"

--- a/roles/vstat-predeploy/tasks/kvm.yml
+++ b/roles/vstat-predeploy/tasks/kvm.yml
@@ -23,14 +23,21 @@
   fail: msg="Required network bridge not found"
   when: ("{{ mgmt_bridge }}" not in ansible_interfaces)
 
-- name: If RedHat, install packages for RedHat OS family distros
-  yum: name={{ item }} state=present
-  with_items:
-   - qemu-kvm
-   - libvirt
-   - bridge-utils
-   - libguestfs-tools
-   - libvirt-python
+- block:
+  - name: If RedHat, install packages for RedHat OS family distros
+    yum: name={{ item }} state=present
+    with_items:
+     - qemu-kvm
+     - libvirt
+     - bridge-utils
+     - libguestfs-tools
+     - libvirt-python
+
+  - service:
+    name: libvirtd
+    enabled: yes
+    state: started
+
   when: ansible_os_family == "RedHat"
   delegate_to: "{{ target_server }}"
   remote_user: "{{ target_server_username }}"


### PR DESCRIPTION
When installing libvirt on a server, on RedHat the service is not started and deployment fails

Should really refactor this and create a single task for installing libvirt, instead of this copy/paste collection of files...