### PR TITLE
Set yum proxy when installing py-netaddr

### DIFF
--- a/roles/validate-build-vars/tasks/main.yml
+++ b/roles/validate-build-vars/tasks/main.yml
@@ -1,12 +1,22 @@
 ---
-- name: Install packages for RedHat OS family distros
-  yum: name=python-netaddr state=present
-  when: ansible_os_family == "RedHat"
-  delegate_to: "{{ ansible_deployment_host }}"
-  remote_user: "{{ ansible_sudo_username }}"
-  environment:
-    http_proxy: "{{ yum_proxy }}"
-    https_proxy: "{{ yum_proxy }}"
+- block:
+  - name: Install packages for RedHat OS family distros
+    yum: name=python-netaddr state=present
+    when: ansible_os_family == "RedHat"
+    delegate_to: "{{ ansible_deployment_host }}"
+    remote_user: "{{ ansible_sudo_username }}"
+    environment:
+      http_proxy: "{{ yum_proxy }}"
+      https_proxy: "{{ yum_proxy }}"
+  when: yum_proxy != 'NONE'
+
+- block:
+  - name: Install packages for RedHat OS family distros
+    yum: name=python-netaddr state=present
+    when: ansible_os_family == "RedHat"
+    delegate_to: "{{ ansible_deployment_host }}"
+    remote_user: "{{ ansible_sudo_username }}"
+  when: yum_proxy == 'NONE'
 
 - name: Install python-netaddr package for Debian OS family distros
   apt: name=python-netaddr state=present


### PR DESCRIPTION
Yum task is fairly brain dead, it tries to reach the repo even when the package is already installed

We may need to set a proxy