### PR TITLE
Fixing few issues in vstat upgrade related roles

### DIFF
--- a/roles/build-upgrade/tasks/get_paths.yml
+++ b/roles/build-upgrade/tasks/get_paths.yml
@@ -23,7 +23,7 @@
 
   - block: # QCOW2
     - name: Find name of current VSD QCOW2 File
-      find: path="{{ nuage_unzipped_files_dir }}/vsd/qcow2"  pattern="*.qcow2" recurse=yes
+      find: path="{{ nuage_upgrade_unzipped_files_dir }}/vsd/qcow2"  pattern="*.qcow2" recurse=yes
       register: rc_vsd_file_current
     - debug: var=rc_vsd_file_current verbosity=1
     - name: Verify that a VSD QCOW2 file was found

--- a/roles/vstat-data-backup/tasks/main.yml
+++ b/roles/vstat-data-backup/tasks/main.yml
@@ -10,7 +10,9 @@
     dest: "{{ vstat_nfs_backup_path }}"
     state: directory
     mode: 0777
-    recurse: yes
+    recurse: yes 
+    owner: elasticsearch
+    group: elasticsearch
   remote_user: root
  
 - name: Mount the nfs folder on to vstat vm
@@ -48,22 +50,27 @@
 - block:
   - name: Set name of backup directory
     set_fact: backup_dir_name="backup-{{ inventory_hostname }}-{{ ansible_date_time.iso8601_basic_short }}/"
+    run_once: true
 
   - name: Set name of vstat backup dir
     set_fact: 
       vstat_backup_dir: "{{ vstat_nfs_backup_path }}/{{ backup_dir_name }}"
+    run_once: true
 
   - name: Create backup dir
     file:
       dest: "{{ vstat_backup_dir }}"
       state: directory
     remote_user: root
+    run_once: true
  
   - name: Get the username running the playbooks
     local_action: command whoami
     register: username_on_the_host
+    run_once: true
 
   - debug: var=username_on_the_host
+    run_once: true
  
   - name: Create backup dir on ansible_deployment_host
     file:
@@ -73,6 +80,7 @@
       group: "{{ username_on_the_host.stdout }}"
     remote_user: "{{ ansible_sudo_username }}"
     delegate_to: "{{ ansible_deployment_host }}"
+    run_once: true
 
   - name: Cleanup backup dir in elasticseach.yml file
     lineinfile:
@@ -93,6 +101,7 @@
       owner: "elasticsearch"
       group: "elasticsearch"
       recurse: yes
+      mode: 0777
     remote_user: root
 
   - name: Restart elasticsearch process
@@ -127,50 +136,62 @@
         dest=/tmp/
     with_items: "{{ vstat_backup_scripts_file_list }}"
     remote_user: root
+    run_once: true
   
   - name: Set the repo name to be created
     set_fact:
       repo_name: "{{ ansible_date_time.iso8601_basic_short }}"
+    run_once: true
 
   - name: Create a repository to backup ES data
     command: "python /tmp/{{ create_repo }}"
     remote_user: root 
+    run_once: true
 
   - name: Get the repo created by backup script
     command: "python /tmp/{{ show_repo }}"
     register: repo_path
     remote_user: root
+    run_once: true
 
   - name: Print contents of show_repo output when verbosity >= 1
     debug: var=repo_path verbosity=1
+    run_once: true
 
   - name: Verify repo is created
     assert:
       that: '"Error in getting repo" not in repo_path.stdout'
       msg: Failed to verify the repo created
+    run_once: true
 
   - name: Set the snapshot name to be created
     set_fact:
       snap_name: "{{ ansible_date_time.iso8601_basic_short }}"
+    run_once: true
 
   - name: Create snapshot with all indicies
     command: "python /tmp/{{ create_snapshot }}"
     register: snapshot
     remote_user: root
+    run_once: true
 
   - name: Print contents of create_snapshot output when verbosity >= 1
     debug: var=snapshot verbosity=1
+    run_once: true
 
   - name: Get the contents of created snapshot
     command: "python /tmp/{{ show_snapshot }}"
     register: snapshot_contents
     remote_user: root
+    run_once: true
 
   - name: Create local variable with snap_contents output to json
     set_fact: snapshot_contents_json="{{ snapshot_contents.stdout|snapshot_list_indices_to_json }}"
+    run_once: true
 
   - name: Print contents of snapshot_contents output when verbosity >= 1
     debug: var=snapshot_contents verbosity=1
+    run_once: true
 
   - block:
     - name: Verify the contents of the snapshot created
@@ -179,35 +200,42 @@
         msg: "{{ item }} index was not found"
       with_items: "{{ snapshot_contents_json['indices'] }}"
     when: list_of_indices is defined
+    run_once: true
 
   - block:
     - name: Get the list of all inices
       command: "python /tmp/{{ get_indices }}"
       remote_user: root
       register: indices_output
+      run_once: true
 
     - name: Verify the contents of the snapshot created
       assert:
         that: '"{{ item }}" in indices_output.stdout'
         msg: "{{ item }} index was not found"
       with_items: "{{ snapshot_contents_json['indices'] }}"
+      run_once: true
     when: list_of_indices is not defined
 
   - name: get the username running the deploy
     local_action: command whoami
     register: username_on_the_host
+    run_once: true
  
   - debug: var=username_on_the_host verbosity=1
+    run_once: true
 
   - name: Copy the elasticsearch backup folder to ansible_deployment_host
     command: "{{ transfer_backup }}"
     remote_user: "{{ username_on_the_host.stdout }}"
     delegate_to: "{{ ansible_deployment_host }}"
+    run_once: true
 
   - name: Create symbolic link to backup location
     file: dest="/tmp/backup-{{ inventory_hostname }}-latest" src="/tmp/{{ backup_dir_name }}"  state=link
     remote_user: "{{ ansible_sudo_username }}"
     delegate_to: "{{ ansible_deployment_host }}"
+    run_once: true
 
   - name: Create file to store repo and snapshot names to use them in migrate role
     copy:
@@ -215,6 +243,7 @@
       dest: "/tmp/backup-{{ inventory_hostname }}-latest/repo_snapshot_name"
     remote_user: "{{ ansible_sudo_username }}"
     delegate_to: "{{ ansible_deployment_host }}"
+    run_once: true
   when: 
     - upgrade_from_version != '4.0.1' 
 

--- a/roles/vstat-data-migrate/tasks/main.yml
+++ b/roles/vstat-data-migrate/tasks/main.yml
@@ -39,13 +39,21 @@
         dest=/tmp/
     with_items: "{{ vstat_backup_scripts_file_list }}"
     remote_user: root
+    run_once: true
+   
+  - name: Pull facts of localhost
+    action: setup
+    connection: local
+    remote_user: "{{ ansible_sudo_username }}"
 
   - name: Set name of backup directory
     set_fact: backup_dir_name="backup-{{ inventory_hostname }}-{{ ansible_date_time.iso8601_basic_short }}/"
+    run_once: true
 
   - name: Set name of vstat backup dir
     set_fact: 
       vstat_backup_dir: "{{ vstat_nfs_backup_path }}/{{ backup_dir_name }}"
+    run_once: true
 
   - name: Create backup dir
     file:
@@ -54,7 +62,7 @@
       group: "elasticsearch"
       state: directory
       recurse: yes
-      mode: 0775
+      mode: 0777
     remote_user: root
   
   - name: Cleanup backup dir in elasticseach.yml file
@@ -102,32 +110,39 @@
     register: names
     remote_user: "{{ ansible_sudo_username }}"
     delegate_to: "{{ ansible_deployment_host }}"
+    run_once: true
     
   - name: Create repo on the new vstat vm 
     command: "python /tmp/{{ create_repo }}"
     remote_user: root
+    run_once: true
 
   - name: Get the repo created by backup script 
     command: "python /tmp/{{ show_repo }}"
     register: repo_path
     remote_user: root
+    run_once: true
 
   - name: Print contents of show_repo output when verbosity >= 1
     debug: var=repo_path verbosity=1
+    run_once: true
 
   - name: Verify repo is created
     assert:
       that: '"Error in getting repo" not in repo_path.stdout'
       msg: Failed to verify the repo created
+    run_once: true
   
   - name: Get the username running the playbooks
     local_action: command whoami
     register: username_on_the_host
+    run_once: true
   
   - name: Transfer the backup folder to vstat node
     shell: "{{ transfer_backup_folder }}"
     remote_user: "{{ username_on_the_host.stdout }}"
     delegate_to: "{{ ansible_deployment_host }}"
+    run_once: true
    
   - name: Set permissions after transferring the backup files
     file:
@@ -136,27 +151,33 @@
       group: "elasticsearch"
       state: directory
       recurse: yes
-      mode: 0775
+      mode: 0777
     remote_user: root
+    run_once: true
  
   - name: Restore the snapshot on the new vstat VM
     command: "python /tmp/{{ restore_snapshot }}"
     register: restore_snap
     remote_user: root
+    run_once: true
 
   - name: Print contents of restore_snapshot output when verbosity >= 1
     debug: var=restore_snapshot verbosity=1
+    run_once: true
 
   - name: Get the contents of created snapshot
     command: "python /tmp/{{ show_snapshot }}"
     register: snapshot_contents
     remote_user: root
+    run_once: true
 
   - name: Create local variable with snap_contents output to json
     set_fact: snapshot_contents_json="{{ snapshot_contents.stdout|snapshot_list_indices_to_json }}"
+    run_once: true
 
   - name: Print contents of snapshot_contents output when verbosity >= 1
     debug: var=snapshot_contents verbosity=1
+    run_once: true
 
   - block:
     - name: Verify the contents of the snapshot created
@@ -164,6 +185,7 @@
         that: '"{{ item }}" in list_of_indices'
         msg: "{{ item }} index was not found"
       with_items: "{{ snapshot_contents_json['indices'] }}"
+      run_once: true
     when: list_of_indices is defined
 
   - block:
@@ -171,12 +193,14 @@
       command: "python /tmp/{{ get_indices }}"
       remote_user: root
       register: indices_output
+      run_once: true
 
     - name: Verify the contents of the snapshot created
       assert:
         that: '"{{ item }}" in indices_output.stdout'
         msg: "{{ item }} index was not found"
       with_items: "{{ snapshot_contents_json['indices'] }}"
+      run_once: true
     when: list_of_indices is not defined
   when: 
     - inventory_hostname in groups['vstats']
@@ -191,9 +215,11 @@
 
 - name: Print vsd version when verbosity >= 1
   debug: var=upgrade_from_version verbosity=1
+  run_once: true
 
 - name: Print vsd version when verbosity >= 1
   debug: var=vsd_version verbosity=1
+  run_once: true
 
 - block:      
   - name: Stop vsd-stats group on VSD(s)

--- a/roles/vstat-deploy/tasks/non_heat.yml
+++ b/roles/vstat-deploy/tasks/non_heat.yml
@@ -212,7 +212,7 @@
     - vsd_sa_or_ha == 'ha'
     - vstat_standalone
  
-- name: Enable stats collection on the cluster vsds when vstat is clustered
+- name: Enable stats collection on the  vsd(s) when vstat is clustered
   command: /opt/vsd/vsd-stats.sh -e {{ groups['vstats'][0] }},{{ groups['vstats'][1] }},{{ groups['vstats'][2] }}
   delegate_to: "{{ item }}"
   remote_user: root

--- a/vstat_data_backup.yml
+++ b/vstat_data_backup.yml
@@ -2,6 +2,5 @@
 - hosts: vstats
   gather_facts: no
   any_errors_fatal: true
-  run_once: true
   roles:
     - vstat-data-backup

--- a/vstat_data_migrate.yml
+++ b/vstat_data_migrate.yml
@@ -1,8 +1,7 @@
 ---
-- hosts: vsds:vstats
+- hosts: vstats:vsds
   gather_facts: no
   any_errors_fatal: true
-  run_once: true
   vars:
     migrate_current_day_data: true
   roles:

--- a/vstat_upgrade.yml
+++ b/vstat_upgrade.yml
@@ -9,7 +9,6 @@
  
 - hosts: vstats
   gather_facts: no
-  run_once: true
   roles:
     - vstat-data-backup
 


### PR DESCRIPTION
@bacastelli 
1. Moving run_once: true from playbook level to task level in vstat-data-backup and vstat-data-migrate roles.
2. Added missing task to pull facts from localhost in vstat-data-migrate role.
3. Fixed var name in get_paths of build-upgrade role.
4. Corrected task name in vstat-deploy role.