### PR TITLE
removed fixed MAC addresses and PCI addresses

### DIFF
--- a/roles/stcv-predeploy/templates/vSTC.xml.j2
+++ b/roles/stcv-predeploy/templates/vSTC.xml.j2
@@ -25,42 +25,33 @@
       <backingStore/>
       <target dev='hda' bus='ide'/>
       <alias name='ide0-0-0'/>
-      <address type='drive' controller='0' bus='0' target='0' unit='0'/>
     </disk>
     <controller type='ide' index='0'>
       <alias name='ide'/>
-      <address type='pci' domain='0x0000' bus='0x00' slot='0x01' function='0x1'/>
     </controller>
     <controller type='usb' index='0'>
       <alias name='usb'/>
-      <address type='pci' domain='0x0000' bus='0x00' slot='0x01' function='0x2'/>
     </controller>
     <controller type='pci' index='0' model='pci-root'>
       <alias name='pci.0'/>
     </controller>
     <interface type='bridge'>
-      <mac address='52:54:00:b7:0d:27'/>
       <source bridge='{{ mgmt_bridge }}'/>
       <target dev='vnet45'/>
       <model type='virtio'/>
       <alias name='net0'/>
-      <address type='pci' domain='0x0000' bus='0x00' slot='0x03' function='0x0'/>
     </interface>
     <interface type='bridge'>
-      <mac address='52:54:00:92:ea:2d'/>
       <source bridge='{{ data_bridge1 }}'/>
       <target dev='vnet46'/>
       <model type='virtio'/>
       <alias name='net1'/>
-      <address type='pci' domain='0x0000' bus='0x00' slot='0x04' function='0x0'/>
     </interface>
     <interface type='bridge'>
-      <mac address='52:54:00:37:f5:60'/>
       <source bridge='{{ data_bridge2 }}'/>
       <target dev='vnet47'/>
       <model type='virtio'/>
       <alias name='net2'/>
-      <address type='pci' domain='0x0000' bus='0x00' slot='0x05' function='0x0'/>
     </interface>
     <serial type='pty'>
       <source path='/dev/pts/16'/>


### PR DESCRIPTION
Two problems were detected with a current config
1) Fixed MACs on templates is a no-no -> lead to broken datapath if one deploys two STCv on the same hyper.

2) pci/ide addresses will be computed by KVM on the fly -> just no need in that, KVM will know better what addresses to assign