### PR TITLE
handle non existent vms/vcenter connection errors for vid destroy

### DIFF
--- a/roles/vsd-destroy/tasks/vcenter.yml
+++ b/roles/vsd-destroy/tasks/vcenter.yml
@@ -29,9 +29,6 @@
 
 - debug: var=vsd_vm_facts verbosity=1
 
-- debug: msg="{{ vsd_vm_facts.exception }}" verbosity=1
-  when: vsd_vm_facts.exception is defined
-
 - fail: msg="Exception found {{ vsd_vm_facts.exception }}"
   when: vsd_vm_facts.exception is defined
 


### PR DESCRIPTION
Added back ignore errors for finding is vm exist on vcenter so if vm does not exist , playbook will gracefully complete. 
Added code to check if an exception has occurred in the above task which is the case for incorrect vcenter target host etc.. 