### PR TITLE
Add support for upgrade and rollback for VCIN

### DIFF
--- a/roles/build-upgrade/templates/vcin.j2
+++ b/roles/build-upgrade/templates/vcin.j2
@@ -11,6 +11,7 @@ vmname: {{ item.vmname }}
 {% else %}
 vmname: {{ item.hostname }}
 {% endif %}
+upgrade_vmname: {{ item.upgrade_vmname }}
 mgmt_ip: {{ item.mgmt_ip }}
 mgmt_gateway: {{ item.mgmt_gateway }}
 mgmt_netmask: {{ item.mgmt_netmask }}
@@ -18,11 +19,15 @@ mgmt_netmask: {{ item.mgmt_netmask }}
 {% if item.target_server_type | match("kvm") %}
 vcin_qcow2_path: {{ vcin_qcow2_path }}
 vcin_qcow2_file_name: {{ vcin_qcow2_file_name }}
+vsd_qcow2_path: {{ vsd_qcow2_path }}
+vsd_qcow2_file_name: {{ vsd_qcow2_file_name }}
 {% endif %}
 
 {% if item.target_server_type | match("vcenter") %}
 vcin_ova_path: {{ vcin_ova_path }}
 vcin_ova_file_name: {{ vcin_ova_file_name }}
+vsd_ova_path: {{ vsd_ova_path }}
+vsd_ova_file_name: {{ vsd_ova_file_name }}
 {% endif %}
 {% endif %}
 

--- a/roles/vcin-health/tasks/main.yml
+++ b/roles/vcin-health/tasks/main.yml
@@ -1,0 +1,30 @@
+---
+- include: report_header.yml
+
+- name: Get current version of VSD software
+  command: echo $VSD_VERSION
+  register: vsd_version
+  remote_user: "root"
+
+- name: Write VSD version to json file
+  nuage_append: filename="{{ report_path }}" text="{{ vsd_version.stdout | to_nice_json}}\n"
+  delegate_to: "{{ ansible_deployment_host }}"
+  remote_user: "{{ ansible_sudo_username }}"
+
+- name: Get current network config 
+  network_info:
+    mac_addr: False
+  register: net_conf
+  remote_user: root
+ 
+- name: Print network config when verbosity >= 1
+  debug: var=net_conf.info verbosity=1
+ 
+- name: Write network config to json file
+  nuage_append: filename="{{ report_path }}" text="{{ net_conf.info | to_nice_json}}\n"
+  delegate_to: "{{ ansible_deployment_host }}"
+  remote_user: "{{ ansible_sudo_username }}"
+
+- include: monit_status.yml
+
+- include: report_footer.yml

--- a/roles/vcin-health/tasks/monit_status.yml
+++ b/roles/vcin-health/tasks/monit_status.yml
@@ -1,0 +1,13 @@
+- name: Get monit summary for vsd processes
+  vsd_monit: 
+    state: summary
+  register: vsd_proc
+  remote_user: root
+
+- name: Print monit status when verbosity >= 1
+  debug: var=vsd_proc verbosity=1
+
+- name: Write vsd monit status to json file
+  nuage_append: filename="{{ report_path }}" text="{{ inventory_hostname }} {{ vsd_proc.state | to_nice_json}}\n"
+  delegate_to: "{{ ansible_deployment_host }}"
+  remote_user: "{{ ansible_sudo_username }}"

--- a/roles/vcin-health/tasks/report_footer.yml
+++ b/roles/vcin-health/tasks/report_footer.yml
@@ -1,0 +1,12 @@
+- name: Write seperator to report file
+  nuage_append: filename="{{ report_path }}" text="================================================================================\n"
+  remote_user: "{{ ansible_sudo_username }}"
+  delegate_to: "{{ ansible_deployment_host }}"
+  run_once: true
+
+- name: Write title to report file
+  nuage_append: filename="{{ report_path }}" text="VSD Health Report End\n"
+  remote_user: "{{ ansible_sudo_username }}"
+  delegate_to: "{{ ansible_deployment_host }}"
+  run_once: true
+

--- a/roles/vcin-health/tasks/report_header.yml
+++ b/roles/vcin-health/tasks/report_header.yml
@@ -1,0 +1,42 @@
+- name: Pull facts of localhost
+  connection: local
+  action: setup
+
+- name: Create report folder on ansible deployment host
+  file:
+    path: "{{ playbook_dir}}/reports/"
+    state: directory
+  remote_user: "{{ ansible_sudo_username }}"
+  delegate_to: "{{ ansible_deployment_host }}"
+  run_once: true
+
+- name: Set path to write report
+  set_fact:
+    report_path: "{{ playbook_dir }}/reports/{{ report_filename }}-{{ mgmt_ip }}"
+
+- name: Clean up tmp files from previous runs
+  file:
+    path: "{{ report_path }}"
+    state: absent
+  remote_user: "{{ ansible_sudo_username }}"
+  delegate_to: "{{ ansible_deployment_host }}"
+  run_once: true
+
+- name: Write title to report file
+  nuage_append: filename="{{ report_path }}" text="VSD Health Report Start\n"
+  remote_user: "{{ ansible_sudo_username }}"
+  delegate_to: "{{ ansible_deployment_host }}"
+  run_once: true
+
+- name: Write date to report file
+  nuage_append: filename="{{ report_path }}" text="{{ ansible_date_time.date }}@{{ ansible_date_time.time }}\n"
+  remote_user: "{{ ansible_sudo_username }}"
+  delegate_to: "{{ ansible_deployment_host }}"
+  run_once: true
+
+- name: Write seperator to report file
+  nuage_append: filename="{{ report_path }}" text="================================================================================\n"
+  remote_user: "{{ ansible_sudo_username }}"
+  delegate_to: "{{ ansible_deployment_host }}"
+  run_once: true
+

--- a/roles/vcin-predeploy/tasks/kvm.yml
+++ b/roles/vcin-predeploy/tasks/kvm.yml
@@ -21,7 +21,7 @@
 
 - name: Check target bridges
   fail: msg="Required network bridges not found"
-  when: mgmt_bridge not in ansible_interfaces)
+  when: mgmt_bridge not in ansible_interfaces
 
 - name: If RedHat, install packages for RedHat OS family distros
   yum: name={{ item }} state=present

--- a/roles/vsd-dbbackup/tasks/main.yml
+++ b/roles/vsd-dbbackup/tasks/main.yml
@@ -55,17 +55,19 @@
   delegate_to: "{{ ansible_deployment_host }}"
   run_once: true
 
-- name: Enable maintainance mode on all l3/l2 domains
-  vsd_maintainance:
-    vsd_auth:
-      "{{ vsd_auth }}"
-    state: enabled
-    api_version: "{{ vsd_version.stdout }}"
-  register: mode_status
-  delegate_to: 127.0.0.1
+- block:
+  - name: Enable maintainance mode on all l3/l2 domains
+    vsd_maintainance:
+      vsd_auth:
+        "{{ vsd_auth }}"
+      state: enabled
+      api_version: "{{ vsd_version.stdout }}"
+    register: mode_status
+    delegate_to: 127.0.0.1
 
-- name: Print vsd maintainance mode output when verbosity >= 1
-  debug: var=mode_status verbosity=1
+  - name: Print vsd maintainance mode output when verbosity >= 1
+    debug: var=mode_status verbosity=1
+  when: inventory_hostname in groups['vsds']
 
 - name: Reading the status of the DB upgrade directory
   stat:
@@ -90,38 +92,40 @@
       - "'nuageDbUpgrade' == db.stdout"
     msg: "Could not find nuageDbUpgrade database in mysql"
 
-- name: Read gateway purge timer
-  config_vsd_system:
-    vsd_auth:
-      "{{ vsd_auth }}"
-    get_gateway_purge_time: True
-    api_version: "{{ vsd_version.stdout }}"
-  register: update_time_status
-  remote_user: "{{ ansible_sudo_username }}"
-  delegate_to: "{{ ansible_deployment_host }}"
-
-- debug: var=update_time_status verbosity=1
-
-- name: Create a file with purge timer value to be restored after VSD upgrade
-  copy:
-    content: "{{ update_time_status.result }}"
-    dest: "{{ vsdbackup_dir }}/purge_time"
-  remote_user: "{{ ansible_sudo_username }}"
-  delegate_to: "{{ ansible_deployment_host }}"
-
-#TODO move updating gateway purge timer from vsd-dbbackup
-- name: Update gateway purge timer 
-  config_vsd_system:
-    vsd_auth:
-      "{{ vsd_auth }}"
-    gateway_purge_time: 86400
-    api_version: "{{ vsd_version.stdout }}"
-  register: update_time_status
-  delegate_to: 127.0.0.1
-
-- name: Print update time output when verbosity >= 1
-  debug: var=update_time_status verbosity=1
-
+- block:
+  - name: Read gateway purge timer
+    config_vsd_system:
+      vsd_auth:
+        "{{ vsd_auth }}"
+      get_gateway_purge_time: True
+      api_version: "{{ vsd_version.stdout }}"
+    register: update_time_status
+    remote_user: "{{ ansible_sudo_username }}"
+    delegate_to: "{{ ansible_deployment_host }}"
+  
+  - debug: var=update_time_status verbosity=1
+  
+  - name: Create a file with purge timer value to be restored after VSD upgrade
+    copy:
+      content: "{{ update_time_status.result }}"
+      dest: "{{ vsdbackup_dir }}/purge_time"
+    remote_user: "{{ ansible_sudo_username }}"
+    delegate_to: "{{ ansible_deployment_host }}"
+  
+  #TODO move updating gateway purge timer from vsd-dbbackup
+  - name: Update gateway purge timer 
+    config_vsd_system:
+      vsd_auth:
+        "{{ vsd_auth }}"
+      gateway_purge_time: 86400
+      api_version: "{{ vsd_version.stdout }}"
+    register: update_time_status
+    delegate_to: 127.0.0.1
+  
+  - name: Print update time output when verbosity >= 1
+    debug: var=update_time_status verbosity=1
+  when: inventory_hostname in groups['vsds']  
+   
 - name: Purge the alarms and event history from database
   shell: "{{ item }}"
   with_items: "{{ purge_cmd }}"

--- a/roles/vsd-rollback/tasks/kvm.yml
+++ b/roles/vsd-rollback/tasks/kvm.yml
@@ -45,7 +45,9 @@
       test_interval_seconds: 30
     with_items: "{{ proc_list['state'].keys() }}"
     remote_user: "root"
- 
+  when: vsd_sa_or_ha | match('sa') or inventory_hostname in groups['vcins'] 
+
+- block: 
   - name: Get current version of VSD software
     command: echo $VSD_VERSION
     register: vsd_version
@@ -92,4 +94,6 @@
                                                                      
   - debug: var=vsc_command_status verbosity=1
   
-  when: vsd_sa_or_ha | match('sa')
+  when: 
+   - vsd_sa_or_ha | match('sa')
+   - inventory_hostname not in groups['vcins']

--- a/roles/vsd-upgrade/tasks/copy_backup_files.yml
+++ b/roles/vsd-upgrade/tasks/copy_backup_files.yml
@@ -12,7 +12,6 @@
         (?i)password: "Alcateldc"
     delegate_to: "{{ ansible_deployment_host }}"
     remote_user: "{{ ansible_sudo_username }}"
-    delegate_to: localhost
   when: target_server_type | match('heat')
 
 - block:

--- a/roles/vsd-upgrade/tasks/main.yml
+++ b/roles/vsd-upgrade/tasks/main.yml
@@ -6,8 +6,10 @@
     remote_user: "root"
 
   - name: Print vsd_version output when verbosity >= 1
-    debug: var=vsd_version verbosity=1
-  when: (inventory_hostname == groups['vsds'][0] and vsd_sa_or_ha | match("sa")) or (inventory_hostname == groups['vsds'][1] and vsd_sa_or_ha | match("ha"))
+    debug: var=vsd_old_version verbosity=1
+  when: 
+    - inventory_hostname in groups['vsds']
+    - inventory_hostname == groups['vsds'][0] and vsd_sa_or_ha | match("sa")) or (inventory_hostname == groups['vsds'][1] and vsd_sa_or_ha | match("ha"))
 
 - block:
   - name: Stop vsd services gracefully
@@ -22,8 +24,7 @@
       include_role: 
         name: vsd-destroy
       vars:
-        preserve_vsd_for_rollback: True
-        rollback: False
+        nuage_upgrade: True
     when: inventory_hostname in groups['vsd_node2'] or inventory_hostname in groups['vsd_node3']
   
   - block:
@@ -31,8 +32,7 @@
       include_role: 
         name: vsd-destroy
       vars:
-        preserve_vsd_for_rollback: False
-        rollback: False
+         nuage_upgrade: True
     when: inventory_hostname in groups['vsd_node1'] 
   when: vsd_sa_or_ha | match('ha')
 
@@ -41,8 +41,7 @@
     include_role: 
       name: vsd-destroy
     vars:
-      preserve_vsd_for_rollback: True
-      rollback: False
+      nuage_upgrade: True
   when: vsd_sa_or_ha | match('sa')
 
 - name: Deploy VSD nodes with new version
@@ -58,9 +57,6 @@
     delay: 1
 
 - include: copy_backup_files.yml
-  tags:
-   - vcin
-   - vsd
 
 #TODO: 
 #- name: Compare network information of VSD's across pre-uppgrade and upgrade
@@ -160,4 +156,6 @@
       register: update_time_status
       delegate_to: 127.0.0.1
     when: vsd_sa_or_ha | match("sa")
-  when: (inventory_hostname == groups['vsds'][0] and vsd_sa_or_ha | match("sa")) or (inventory_hostname == groups['vsds'][1] and vsd_sa_or_ha | match("ha"))
+  when: 
+   - inventory_hostname in groups['vsds']
+   - (inventory_hostname == groups['vsds'][0] and vsd_sa_or_ha | match("sa")) or (inventory_hostname == groups['vsds'][1] and vsd_sa_or_ha | match("ha"))

--- a/vcin_rollback.yml
+++ b/vcin_rollback.yml
@@ -1,0 +1,15 @@
+---
+- hosts: vcins
+  gather_facts: no
+  vars: 
+    - vsd_2_rb: ""
+  roles:
+    - vsd-rollback
+
+- hosts: vcins
+  any_errors_fatal: true
+  gather_facts: no
+  vars:
+    report_filename: vsd_post_rollback_report.txt
+  roles:
+    - vcin-health

--- a/vcin_upgrade.yml
+++ b/vcin_upgrade.yml
@@ -3,9 +3,8 @@
   any_errors_fatal: true
   vars:
     report_filename: vcin_pre_upgrade_report.txt
-    vsd_sa_or_ha: sa
   roles:
-    - vsd-health
+    - vcin-health
  
 - hosts: vcins
   gather_facts: no
@@ -13,11 +12,7 @@
     vsd_sa_or_ha: sa
   roles:
     - vsd-dbbackup
-    #- vsd-upgrade 
-    # TODO: The vsd-upgrade is tailored to proper VSD nodes. For VCIN this can be done by:
-    #   - vcin-predeploy
-    #   - vsd-upgrade --tags vcin
-    #   - vcin-deploy
+    - vsd-upgrade 
 
 - hosts: vcins
   any_errors_fatal: true
@@ -25,4 +20,4 @@
     report_filename: vcins_post_upgrade_report.txt
     vsd_sa_or_ha: sa
   roles:
-    - vsd-health
+    - vcin-health


### PR DESCRIPTION
This involves changes required to support upgrade/rollback of the VCIN node.

Notably it relies now on the `vsd-xxxxx`  roles for backup, rollback, upgrade, deploy, predeploy.
I suggest to do the same for all VCIN-roles since this would reduce the number of roles to maintain.
