### PR TITLE
Fix path used for generating firewall template rules

### DIFF
--- a/roles/vstat-deploy/tasks/non_heat.yml
+++ b/roles/vstat-deploy/tasks/non_heat.yml
@@ -141,12 +141,12 @@
   when: vsd_sa_or_ha == 'sa'
 
 - name: Create firewall vars file on ansible host
-  template: src="{{ playbook_dir }}/roles/vstat-deploy/templates/firewall.j2" dest="{{ playbook_dir }}/roles/vstat-deploy/vars/main.yml" backup=no mode=0755
+  template: src="{{ playbook_dir }}/roles/vstat-deploy/templates/firewall.j2" dest="/tmp/metro_stats_firewall_rules.yml" backup=no mode=0755
   delegate_to: "{{ ansible_deployment_host }}"
   remote_user: "{{ ansible_sudo_username }}"
 
 - name: Include variable file.
-  include_vars: main.yml
+  include_vars: /tmp/metro_stats_firewall_rules.yml
   remote_user: "root"
 
 - name: Config firewall on VSTAT vm to accept conn on ports 9200,9300 from vsd(s)


### PR DESCRIPTION
When using the container host as Ansible host, the task fails because the path doesn't exist.
Simply generate the template under /tmp instead