### PR TITLE
update pre-deploy roles to support wait for vmwaretools on ansible 2.2 and 2.3

### DIFF
--- a/roles/gvm-predeploy/tasks/vcenter.yml
+++ b/roles/gvm-predeploy/tasks/vcenter.yml
@@ -14,14 +14,14 @@
     name: "{{ inventory_hostname }}"
     validate_certs: no
     state: gatherfacts
-  register: vsd_vm_facts
+  register: gvm_vm_facts
   ignore_errors: yes
 
-- debug: var=vsd_vm_facts verbosity=1
+- debug: var=gvm_vm_facts verbosity=1
 
 - name: Verify the VSD VM does not exist
   assert:
-    that: "vsd_vm_facts.failed"
+    that: "gvm_vm_facts.failed"
     msg: "VM {{ inventory_hostname }} already exists, quiting"
 
 - name: Deploy VSD Image on vCenter
@@ -39,32 +39,50 @@
     "{{ vsd_ova_path }}/{{ vsd_ova_file_name }}"
     vi://'{{ vcenter.username | urlencode }}':'{{ vcenter.password | urlencode }}'@{{ target_server }}/{{ vcenter.datacenter }}/host/{{ vcenter.cluster }}
 
-- name: Waiting 120 seconds to make sure the VSD is up
-  pause:
-    seconds: 120
+- block:
+  - name: Waiting until VMware tools becomes available
+    connection: local
+    vmware_guest_tools_wait:
+      hostname: "{{ target_server }}"
+      username: "{{ vcenter.username }}"
+      password: "{{ vcenter.password }}"
+      name: "{{ inventory_hostname }}"
+      datacenter: "{{ vcenter.datacenter }}"
+      validate_certs: no
+    register: gvm_vm_facts
+  
+  - debug: var=gvm_vm_facts verbosity=1
+  when: ansible_version.full | version_compare('2.3', '>=')
 
-- name: Gathering info on VM
-  connection: local
-  vmware_guest:
-    hostname: "{{ target_server }}"
-    username: "{{ vcenter.username }}"
-    password: "{{ vcenter.password }}"
-    name: "{{ inventory_hostname }}"
-    validate_certs: no
-    state: gatherfacts
-  register: vsd_vm_facts
+- block:
+  - name: Waiting 120 seconds to make sure the GVM is up
+    pause:
+      seconds: 120
 
-- debug: var=vsd_vm_facts verbosity=1
+  - name: Gathering info on VM
+    connection: local
+    vmware_guest:
+      hostname: "{{ target_server }}"
+      username: "{{ vcenter.username }}"
+      password: "{{ vcenter.password }}"
+      name: "{{ vm_name }}"
+      datacenter: "{{ vcenter.datacenter }}"
+      state: gatherfacts
+      validate_certs: no
+    register: gvm_vm_facts
 
-- name: Verify the VSD VM came up correctly
-  assert:
-    that:
-      - "vsd_vm_facts.instance.hw_guest_id is defined"
-      - "not vsd_vm_facts.instance.hw_guest_id is none"
-      - "not vsd_vm_facts.instance.hw_guest_id == ''"
-    msg: "VSD VM {{ inventory_hostname }} did not come up after two minutes"
+  - debug: var=gvm_vm_facts verbosity=1
 
-- name: Writing eth0 network script file to the VSD VM
+  - name: Verify the GVM VM came up correctly
+    assert:
+      that:
+        - "gvm_vm_facts.instance.hw_guest_id is defined"
+        - "not gvm_vm_facts.instance.hw_guest_id is none"
+        - "not gvm_vm_facts.instance.hw_guest_id == ''"
+      msg: "GVM VM {{ inventory_hostname }} did not come up after two minutes"
+  when: ansible_version.full | version_compare('2.3', '<')
+  
+  - name: Writing eth0 network script file to the VSD VM
   connection: local
   vmware_vm_shell:
     hostname: "{{ target_server }}"

--- a/roles/lvm-predeploy/tasks/vcenter.yml
+++ b/roles/lvm-predeploy/tasks/vcenter.yml
@@ -50,30 +50,48 @@
     vi://'{{ vcenter.username | urlencode }}':'{{ vcenter.password | urlencode }}'@{{ target_server }}/{{ vcenter.datacenter }}/host/{{ vcenter.cluster }} 
   when: "'.ovf' in vstat_ova_file_name"
 
-- name: Waiting 120 seconds to make sure the Stats VM is up
-  pause: 
-    seconds: 120
+- block:
+  - name: Waiting until VMware tools becomes available
+    connection: local
+    vmware_guest_tools_wait:
+      hostname: "{{ target_server }}"
+      username: "{{ vcenter.username }}"
+      password: "{{ vcenter.password }}"
+      name: "{{ inventory_hostname }}"
+      datacenter: "{{ vcenter.datacenter }}"
+      validate_certs: no
+    register: vstat_vm_facts
+  
+  - debug: var=vstat_vm_facts verbosity=1
+  when: ansible_version.full | version_compare('2.3', '>=')
 
-- name: Gathering info on VM
-  connection: local
-  vmware_guest:
-    hostname: "{{ target_server }}"
-    username: "{{ vcenter.username }}"
-    password: "{{ vcenter.password }}"
-    name: "{{ inventory_hostname }}"
-    validate_certs: no
-    state: gatherfacts
-  register: vstat_vm_facts
+- block:
+  - name: Waiting 120 seconds to make sure the LVM is up
+    pause:
+      seconds: 120
 
-- debug: var=vstat_vm_facts verbosity=1
+  - name: Gathering info on VM
+    connection: local
+    vmware_guest:
+      hostname: "{{ target_server }}"
+      username: "{{ vcenter.username }}"
+      password: "{{ vcenter.password }}"
+      name: "{{ vm_name }}"
+      datacenter: "{{ vcenter.datacenter }}"
+      state: gatherfacts
+      validate_certs: no
+    register: lvm_vm_facts
 
-- name: Verify the Stats VM came up correctly
-  assert: 
-    that: 
-      - "vstat_vm_facts.instance.hw_guest_id is defined"
-      - "not vstat_vm_facts.instance.hw_guest_id is none"
-      - "not vstat_vm_facts.instance.hw_guest_id == ''"
-    msg: "Stats VM {{ inventory_hostname }} did not come up after two minutes"
+  - debug: var=lvm_vm_facts verbosity=1
+
+  - name: Verify the LVM VM came up correctly
+    assert:
+      that:
+        - "lvm_vm_facts.instance.hw_guest_id is defined"
+        - "not lvm_vm_facts.instance.hw_guest_id is none"
+        - "not lvm_vm_facts.instance.hw_guest_id == ''"
+      msg: "LVM VM {{ inventory_hostname }} did not come up after two minutes"
+  when: ansible_version.full | version_compare('2.3', '<')
 
 - name: Writing eth0 network script file to the Stats VM
   connection: local

--- a/roles/nsgv-predeploy/tasks/vcenter.yml
+++ b/roles/nsgv-predeploy/tasks/vcenter.yml
@@ -97,19 +97,45 @@
     remote_user: "{{ ansible_sudo_username }}"
   when: bootstrap_method == 'zfb_external'
 
-- name: Waiting 120 seconds to make sure the NSGv VM is up
-  pause: 
-    seconds: 120
+- block:
+  - name: Waiting until VMware tools becomes available
+    connection: local
+    vmware_guest_tools_wait:
+      hostname: "{{ target_server }}"
+      username: "{{ vcenter.username }}"
+      password: "{{ vcenter.password }}"
+      name: "{{ vmname }}"
+      datacenter: "{{ vcenter.datacenter }}"
+      validate_certs: no
+    register: nsgv_vm_facts
+  
+  - debug: var=nsgv_vm_facts verbosity=1
+  when: ansible_version.full | version_compare('2.3', '>=')
 
-- name: Gathering info on VM
-  connection: local
-  vmware_guest:
-    hostname: "{{ target_server }}"
-    username: "{{ vcenter.username }}"
-    password: "{{ vcenter.password }}"
-    name: "{{ vmname }}"
-    validate_certs: no
-    state: gatherfacts
-  register: nsgv_vm_facts
+- block:
+  - name: Waiting 120 seconds to make sure the NSGv is up
+    pause:
+      seconds: 120
 
-- debug: var=nsgv_vm_facts verbosity=1
+  - name: Gathering info on VM
+    connection: local
+    vmware_guest:
+      hostname: "{{ target_server }}"
+      username: "{{ vcenter.username }}"
+      password: "{{ vcenter.password }}"
+      name: "{{ vm_name }}"
+      datacenter: "{{ vcenter.datacenter }}"
+      state: gatherfacts
+      validate_certs: no
+    register: nsgv_vm_facts
+
+  - debug: var=nsgv_vm_facts verbosity=1
+
+  - name: Verify the NSGv VM came up correctly
+    assert:
+      that:
+        - "nsgv_vm_facts.instance.hw_guest_id is defined"
+        - "not nsgv_vm_facts.instance.hw_guest_id is none"
+        - "not nsgv_vm_facts.instance.hw_guest_id == ''"
+      msg: "NSGv VM {{ inventory_hostname }} did not come up after two minutes"
+  when: ansible_version.full | version_compare('2.3', '<')

--- a/roles/stcv-predeploy/tasks/vcenter.yml
+++ b/roles/stcv-predeploy/tasks/vcenter.yml
@@ -63,28 +63,45 @@
     vi://'{{ vcenter.username | urlencode }}':'{{ vcenter.password | urlencode }}'@{{ target_server }}/{{ vcenter.datacenter }}/host/{{ vcenter.cluster }}
   when: data_bridge2 is defined
 
-- name: Waiting 120 seconds to make sure the STCv VM is up
-  pause:
-    seconds: 120
+- block:
+  - name: Waiting until VMware tools becomes available
+    connection: local
+    vmware_guest_tools_wait:
+      hostname: "{{ target_server }}"
+      username: "{{ vcenter.username }}"
+      password: "{{ vcenter.password }}"
+      name: "{{ vm_hostname }}"
+      datacenter: "{{ vcenter.datacenter }}"
+      validate_certs: no
+    register: stcv_vm_facts
+  
+  - debug: var=stcv_vm_facts verbosity=1
+  when: ansible_version.full | version_compare('2.3', '>=')
 
-- name: Gathering info on VM
-  connection: local
-  vmware_guest:
-    hostname: "{{ target_server }}"
-    username: "{{ vcenter.username }}"
-    password: "{{ vcenter.password }}"
-    name: "{{ vm_hostname }}"
-    validate_certs: no
-    state: gatherfacts
-  register: stcv_vm_facts
+- block:
+  - name: Waiting 120 seconds to make sure the STCv is up
+    pause:
+      seconds: 120
 
-- debug: var=stcv_vm_facts verbosity=1
+  - name: Gathering info on VM
+    connection: local
+    vmware_guest:
+      hostname: "{{ target_server }}"
+      username: "{{ vcenter.username }}"
+      password: "{{ vcenter.password }}"
+      name: "{{ vm_name }}"
+      datacenter: "{{ vcenter.datacenter }}"
+      state: gatherfacts
+      validate_certs: no
+    register: stcv_vm_facts
 
-- name: Verify the STCv VM came up correctly
-  assert:
-    that:
-      - "stcv_vm_facts.instance.hw_product_uuid is defined"
-      - "not stcv_vm_facts.instance.hw_product_uuid is none"
-      - "not stcv_vm_facts.instance.hw_product_uuid == ''"
-    msg: "STVc VM {{ vm_hostname }} did not come up after two minutes"
+  - debug: var=stcv_vm_facts verbosity=1
 
+  - name: Verify the STCv VM came up correctly
+    assert:
+      that:
+        - "stcv_vm_facts.instance.hw_guest_id is defined"
+        - "not stcv_vm_facts.instance.hw_guest_id is none"
+        - "not stcv_vm_facts.instance.hw_guest_id == ''"
+      msg: "STCv VM {{ inventory_hostname }} did not come up after two minutes"
+  when: ansible_version.full | version_compare('2.3', '<')

--- a/roles/vcin-predeploy/tasks/vcenter.yml
+++ b/roles/vcin-predeploy/tasks/vcenter.yml
@@ -31,32 +31,50 @@
     -n={{ inventory_hostname }}
     --net:"VM Network={{ mgmt_bridge }}"
     "{{ vcin_ova_path }}/{{ vcin_ova_file_name }}"
-    vi://'{{ vcenter.username | urlencode }}':'{{ vcenter.password | urlencode }}'@{{ target_server }}/{{ vcenter.datacenter }}/host/{{ vcenter.cluster }} 
+    vi://'{{ vcenter.username | urlencode }}':'{{ vcenter.password | urlencode }}'@{{ target_server }}/{{ vcenter.datacenter }}/host/{{ vcenter.cluster }}
 
-- name: Waiting 120 seconds to make sure the VCIN is up
-  pause: 
-    seconds: 120
+- block:
+  - name: Waiting until VMware tools becomes available
+    connection: local
+    vmware_guest_tools_wait:
+      hostname: "{{ target_server }}"
+      username: "{{ vcenter.username }}"
+      password: "{{ vcenter.password }}"
+      name: "{{ inventory_hostname }}"
+      datacenter: "{{ vcenter.datacenter }}"
+      validate_certs: no
+    register: vcin_vm_facts
+  
+  - debug: var=vcin_vm_facts verbosity=1
+  when: ansible_version.full | version_compare('2.3', '>=')
 
-- name: Gathering info on VM
-  connection: local
-  vmware_guest:
-    hostname: "{{ target_server }}"
-    username: "{{ vcenter.username }}"
-    password: "{{ vcenter.password }}"
-    name: "{{ inventory_hostname }}"
-    validate_certs: no
-    state: gatherfacts
-  register: vcin_vm_facts
+- block:
+  - name: Waiting 120 seconds to make sure the VCIN is up
+    pause:
+      seconds: 120
 
-- debug: var=vcin_vm_facts verbosity=1
+  - name: Gathering info on VM
+    connection: local
+    vmware_guest:
+      hostname: "{{ target_server }}"
+      username: "{{ vcenter.username }}"
+      password: "{{ vcenter.password }}"
+      name: "{{ vm_name }}"
+      datacenter: "{{ vcenter.datacenter }}"
+      state: gatherfacts
+      validate_certs: no
+    register: vcin_vm_facts
 
-- name: Verify the VCIN VM came up correctly
-  assert: 
-    that: 
-      - "vcin_vm_facts.instance.hw_guest_id is defined"
-      - "not vcin_vm_facts.instance.hw_guest_id is none"
-      - "not vcin_vm_facts.instance.hw_guest_id == ''"
-    msg: "VCIN VM {{ inventory_hostname }} did not come up after two minutes"
+  - debug: var=vcin_vm_facts verbosity=1
+
+  - name: Verify the VCIN VM came up correctly
+    assert:
+      that:
+        - "vcin_vm_facts.instance.hw_guest_id is defined"
+        - "not vcin_vm_facts.instance.hw_guest_id is none"
+        - "not vcin_vm_facts.instance.hw_guest_id == ''"
+      msg: "VCIN VM {{ inventory_hostname }} did not come up after two minutes"
+  when: ansible_version.full | version_compare('2.3', '<')
 
 - name: Writing eth0 network script file to the VCIN VM
   connection: local

--- a/roles/vnsutil-predeploy/tasks/vcenter.yml
+++ b/roles/vnsutil-predeploy/tasks/vcenter.yml
@@ -33,30 +33,48 @@
     "{{ vnsutil_ova_path }}/{{ vnsutil_ova_file_name }}"
     vi://'{{ vcenter.username | urlencode }}':'{{ vcenter.password | urlencode }}'@{{ target_server }}/{{ vcenter.datacenter }}/host/{{ vcenter.cluster }} 
 
-- name: Waiting 120 seconds to make sure the VNSUTIL is up
-  pause: 
-    seconds: 120
+- block:
+  - name: Waiting until VMware tools becomes available
+    connection: local
+    vmware_guest_tools_wait:
+      hostname: "{{ target_server }}"
+      username: "{{ vcenter.username }}"
+      password: "{{ vcenter.password }}"
+      name: "{{ vmname }}"
+      datacenter: "{{ vcenter.datacenter }}"
+      validate_certs: no
+    register: vnsutil_vm_facts
+  
+  - debug: var=vnsutil_vm_facts verbosity=1
+  when: ansible_version.full | version_compare('2.3', '>=')
 
-- name: Gathering info on VM
-  connection: local
-  vmware_guest:
-    hostname: "{{ target_server }}"
-    username: "{{ vcenter.username }}"
-    password: "{{ vcenter.password }}"
-    name: "{{ vmname }}"
-    validate_certs: no
-    state: gatherfacts
-  register: vnsutil_vm_facts
+- block:
+  - name: Waiting 120 seconds to make sure the VNSUTIL is up
+    pause:
+      seconds: 120
 
-- debug: var=vnsutil_vm_facts verbosity=1
+  - name: Gathering info on VM
+    connection: local
+    vmware_guest:
+      hostname: "{{ target_server }}"
+      username: "{{ vcenter.username }}"
+      password: "{{ vcenter.password }}"
+      name: "{{ vm_name }}"
+      datacenter: "{{ vcenter.datacenter }}"
+      state: gatherfacts
+      validate_certs: no
+    register: vnsutil_vm_facts
 
-- name: Verify the VNSUTIL VM came up correctly
-  assert: 
-    that: 
-      - "vnsutil_vm_facts.instance.hw_guest_id is defined"
-      - "not vnsutil_vm_facts.instance.hw_guest_id is none"
-      - "not vnsutil_vm_facts.instance.hw_guest_id == ''"
-    msg: "VNSUTIL VM {{ vmname }} did not come up after two minutes"
+  - debug: var=vnsutil_vm_facts verbosity=1
+
+  - name: Verify the Stats VM came up correctly
+    assert:
+      that:
+        - "vnsutil_vm_facts.instance.hw_guest_id is defined"  
+        - "not vnsutil_vm_facts.instance.hw_guest_id is none"  
+        - "not vnsutil_vm_facts.instance.hw_guest_id == ''"  
+      msg: "VNSUTIL VM {{ inventory_hostname }} did not come up after two minutes"
+  when: ansible_version.full | version_compare('2.3', '<')
 
 - name: Writing eth0 network script file to the VNSUTIL VM
   connection: local

--- a/roles/vsd-predeploy/tasks/vcenter.yml
+++ b/roles/vsd-predeploy/tasks/vcenter.yml
@@ -53,30 +53,48 @@
     "{{ vsd_ova_path }}/{{ vsd_ova_file_name }}"
     vi://'{{ vcenter.username | urlencode }}':'{{ vcenter.password | urlencode }}'@{{ target_server }}/{{ vcenter.datacenter }}/host/{{ vcenter.cluster }}
 
-- name: Waiting 120 seconds to make sure the VSD is up
-  pause:
-    seconds: 120
+- block:
+  - name: Waiting until VMware tools becomes available
+    connection: local
+    vmware_guest_tools_wait:
+      hostname: "{{ target_server }}"
+      username: "{{ vcenter.username }}"
+      password: "{{ vcenter.password }}"
+      name: "{{ vm_name }}"
+      datacenter: "{{ vcenter.datacenter }}"
+      validate_certs: no
+    register: vsd_vm_facts
+  
+  - debug: var=vsd_vm_facts verbosity=1
+  when: ansible_version.full | version_compare('2.3', '>=')
 
-- name: Gathering info on VM
-  connection: local
-  vmware_guest:
-    hostname: "{{ target_server }}"
-    username: "{{ vcenter.username }}"
-    password: "{{ vcenter.password }}"
-    name: "{{ vm_name }}"
-    validate_certs: no
-    state: gatherfacts
-  register: vsd_vm_facts
+- block:
+  - name: Waiting 120 seconds to make sure the VSD is up
+    pause:
+      seconds: 120
+ 
+  - name: Gathering info on VM
+    connection: local
+    vmware_guest:
+      hostname: "{{ target_server }}"
+      username: "{{ vcenter.username }}"
+      password: "{{ vcenter.password }}"
+      name: "{{ vm_name }}"
+      datacenter: "{{ vcenter.datacenter }}"
+      state: gatherfacts
+      validate_certs: no
+    register: vsd_vm_facts
+  
+  - debug: var=vsd_vm_facts verbosity=1
 
-- debug: var=vsd_vm_facts verbosity=1
-
-- name: Verify the VSD VM came up correctly
-  assert:
-    that:
-      - "vsd_vm_facts.instance.hw_guest_id is defined"
-      - "not vsd_vm_facts.instance.hw_guest_id is none"
-      - "not vsd_vm_facts.instance.hw_guest_id == ''"
-    msg: "VSD VM {{ vm_name }} did not come up after two minutes"
+  - name: Verify the Stats VM came up correctly           
+    assert:             
+      that:             
+        - "vsd_vm_facts.instance.hw_guest_id is defined"              
+        - "not vsd_vm_facts.instance.hw_guest_id is none"             
+        - "not vsd_vm_facts.instance.hw_guest_id == ''"               
+      msg: "VSD VM {{ inventory_hostname }} did not come up after two minutes"
+  when: ansible_version.full | version_compare('2.3', '<')
 
 - name: Writing eth0 network script file to the VSD VM
   connection: local

--- a/roles/vstat-predeploy/tasks/vcenter.yml
+++ b/roles/vstat-predeploy/tasks/vcenter.yml
@@ -70,30 +70,50 @@
     vi://'{{ vcenter.username | urlencode }}':'{{ vcenter.password | urlencode }}'@{{ target_server }}/{{ vcenter.datacenter }}/host/{{ vcenter.cluster }} 
   when: "'.ovf' in vstat_ova_or_ovf_file_name"
 
-- name: Waiting 120 seconds to make sure the Stats VM is up
-  pause: 
-    seconds: 120
+- block:
+  - name: Waiting until VMware tools becomes available
+    connection: local
+    vmware_guest_tools_wait:
+      hostname: "{{ target_server }}"
+      username: "{{ vcenter.username }}"
+      password: "{{ vcenter.password }}"
+      name: "{{ vmname }}"
+      datacenter: "{{ vcenter.datacenter }}"
+      validate_certs: no
+    register: vstat_vm_facts
 
-- name: Gathering info on VM
-  connection: local
-  vmware_guest:
-    hostname: "{{ target_server }}"
-    username: "{{ vcenter.username }}"
-    password: "{{ vcenter.password }}"
-    name: "{{ vmname }}"
-    validate_certs: no
-    state: gatherfacts
-  register: vstat_vm_facts
+  - debug: var=vstat_vm_facts verbosity=1
+  when: ansible_version.full | version_compare('2.3', '>=')
 
-- debug: var=vstat_vm_facts verbosity=1
+- block:
+  - name: Waiting 120 seconds to make sure the VSD is up
+    pause:
+      seconds: 120
 
-- name: Verify the Stats VM came up correctly
-  assert: 
-    that: 
-      - "vstat_vm_facts.instance.hw_guest_id is defined"
-      - "not vstat_vm_facts.instance.hw_guest_id is none"
-      - "not vstat_vm_facts.instance.hw_guest_id == ''"
-    msg: "Stats VM {{ vmname }} did not come up after two minutes"
+  - name: Gathering info on VM
+    connection: local
+    vmware_guest:
+      hostname: "{{ target_server }}"
+      username: "{{ vcenter.username }}"
+      password: "{{ vcenter.password }}"
+      name: "{{ vm_name }}"
+      datacenter: "{{ vcenter.datacenter }}"
+      state: gatherfacts
+      validate_certs: no
+    register: vstat_vm_facts
+
+  - debug: var=vstat_vm_facts verbosity=1
+
+  - name: Verify the Stats VM came up correctly
+    assert:
+      that:
+        - "vstat_vm_facts.instance.hw_guest_id is defined"
+        - "not vstat_vm_facts.instance.hw_guest_id is none"
+        - "not vstat_vm_facts.instance.hw_guest_id == ''"
+      msg: "Stats VM {{ inventory_hostname }} did not come up after two minutes"
+  when: ansible_version.full | version_compare('2.3', '<')
+
+
 
 - name: Writing eth0 network script file to the Stats VM
   connection: local


### PR DESCRIPTION
Changes introduced in PR#288 replaced the way of waiting for vmware tools to be available with new ansible module vmware_guest_wait  . This works with ansible 2.3.1 only. This PR conditionally choose the correct module (vmware_guest/vmware_guest_wait) to use based on ansible version being used.