### PR TITLE
fixing getpaths when vnsutils is not defined

### DIFF
--- a/roles/build/tasks/get_paths.yml
+++ b/roles/build/tasks/get_paths.yml
@@ -501,8 +501,7 @@
       - nsgv_qcow2
   when:
     ( mynsgvs is defined or
-    ( myvnsutils is defined and  myvnsutils | map(attribute='target_server_type') | list | issuperset(["kvm"]) or myvnsutils | map(attribute='target
-_server_type') | list | issuperset(["heat"]) ) and
+    ( myvnsutils is defined and  myvnsutils | map(attribute='target_server_type') | list | issuperset(["kvm"]) or myvnsutils | map(attribute='target_server_type') | list | issuperset(["heat"]) ) and
     ("'install' in vns_operations_list|default(['None'])"))
 
 - block: #OVA/OVF


### PR DESCRIPTION
respond to #315 
conditional logic changed so vnsutils section only plays its part when it is defined, making possible to deploy nsgvs separately 
