### PR TITLE
VCIN host vars fix

### DIFF
--- a/roles/build/templates/vcin.j2
+++ b/roles/build/templates/vcin.j2
@@ -5,17 +5,25 @@
 target_server_type: {{ item.target_server_type }}
 {% if item.target_server_type | match("kvm") or item.target_server_type | match("vcenter")%}
 target_server: {{ item.target_server }}
-
+hostname: {{ item.hostname }}
+{% if item.vmname is defined %}
+vmname: {{ item.vmname }}
+{% else %}
+vmname: {{ item.hostname }}
+{% endif %}
+{% if item.upgrade_vmname is defined %}
+upgrade_vmname: {{ item.upgrade_vmname }}
+{% endif %}
 mgmt_ip: {{ item.mgmt_ip }}
 mgmt_gateway: {{ item.mgmt_gateway }}
 mgmt_netmask: {{ item.mgmt_netmask }}
 {% if item.target_server_type | match("kvm") %}
-vcin_qcow2_path: {{ vcin_qcow2_path }}
-vcin_qcow2_file_name: {{ vcin_qcow2_file_name }}
+vsd_qcow2_path: {{ vsd_qcow2_path }}
+vsd_qcow2_file_name: {{ vsd_qcow2_file_name }}
 {% endif %}
 {% if item.target_server_type | match("vcenter") %}
-vcin_ova_path: {{ vcin_ova_path }}
-vcin_ova_file_name: {{ vcin_ova_file_name }}
+vsd_ova_path: {{ vsd_ova_path }}
+vsd_ova_file_name: {{ vsd_ova_file_name }}
 {% if item.vcenter is defined %}
 vcenter:
   username: {{ item.vcenter.username | default('NONE') }}
@@ -27,9 +35,20 @@ vcenter:
 {% endif %}
 {% endif %}
 
+vsd_sa_or_ha: sa
+
 {% if item.target_server_type | match("heat") %}
-vcin_image: {{ item.vcin_image }}
-vcin_flavor: {{ item.vcin_flavor }}
-vcin_network: {{ item.vcin_network }}
+dhcp: {{ item.dhcp | default('True') }}
+{% if item.dhcp is defined and item.dhcp == False %}
+mgmt_ip: {{ item.mgmt_ip }}
+{% endif %}
+vsd_image: {{ item.vsd_image }}
+vsd_flavor: {{ item.vsd_flavor }}
+vsd_network: {{ item.vsd_network }}
+{% if item.dhcp is defined and item.dhcp == False %}
+vsd_subnet: {{ item.vsd_subnet }}
+{% endif %}
+{% if item.infra_server_name is defined %}
 infra_server_name: {{ item.infra_server_name }}
+{% endif %}
 {% endif %}


### PR DESCRIPTION
As the VCIN playbooks are now removed and the VSD playbooks are used, the build role was not creating the correct host variables for the vcin_predeploy, vcin_deploy and vcin_destroy playbooks.