### PR TITLE
Configure ntpdate on VSD to sync NTP better

### DIFF
--- a/roles/vsd-deploy/tasks/non_heat.yml
+++ b/roles/vsd-deploy/tasks/non_heat.yml
@@ -172,6 +172,7 @@
   lineinfile:
     dest: /etc/ntp/step-tickers
     line: "{{ item }}"
+    create: yes
   with_items: "{{ ntp_server_list }}"
   remote_user: "root"
 
@@ -180,6 +181,7 @@
     name: ntpdate
     enabled: yes
     state: started
+  remote_user: "root"
 
 - name: Start ntpd
   command: service ntpd start


### PR DESCRIPTION
ntpdate should be configured and enabled on each VSD, it speeds up NTP sync upon startup

Patch also increases the number of retries after manually running ntpdate, and disables cloud-init