### PR TITLE
Added check on max length of VSC name

### DIFF
--- a/roles/validate-build-vars/tasks/main.yml
+++ b/roles/validate-build-vars/tasks/main.yml
@@ -37,6 +37,14 @@
     msg: "{{ item }} is not a valid NTP server IP address, quiting"
   with_items: "{{ ntp_server_list }}"
   when: ntp_server_list is defined
+
+- name: Verify that the VSC hostnames are not longer than 32 characters
+  assert:
+    that: "'{{item.hostname}}'|length <= 32"
+    msg: "{{item.hostname}} is too long to be a valid VSC name, quitting"
+  with_items: "{{ myvscs }}"
+  when: myvscs is defined
+
 # TODO:
 # Use the floowing block to disable the feature for now. We need to update our
 # test infrastructure to accomodate.


### PR DESCRIPTION
The system name of a VSC has a maximum length of 32 characters. When the system name is longer, the configuration fails to load. This commit adds an assert in the validate-build-vars role to check for this.