### PR TITLE
Install missing VRS dependency python-six

### DIFF
--- a/roles/vrs-predeploy/tasks/main.yml
+++ b/roles/vrs-predeploy/tasks/main.yml
@@ -39,6 +39,7 @@
    - vconfig
    - libvirt
    - qemu-kvm
+   - python-six
   when: ansible_os_family == "RedHat"
 
 - name: Upgrade all packages on Debian OS family distros
@@ -58,6 +59,7 @@
    - python-libvirt
    - python-twisted-core
    - python-yaml
+   - python-six
    - libjson-perl
    - vlan
    - dkms


### PR DESCRIPTION
In 5.1.1 the RedHat .rpm packages ( at least ) fail to list python-six as a dependency, causing nuage-housekeeper process to fail to start

We can fix this for Metro deployments