### PR TITLE
Fix bug in vstat xml definition

### DIFF
--- a/roles/vstat-predeploy/templates/vstat.xml.j2
+++ b/roles/vstat-predeploy/templates/vstat.xml.j2
@@ -1,5 +1,5 @@
 <domain type='kvm'>
-  <name>{{ vmname }}</name>
+  <name>{{ vm_name }}</name>
   <memory unit='KiB'>{{ vstat_ram }}</memory>
   <currentMemory unit='KiB'>{{ vstat_ram }}</currentMemory>
   <vcpu placement='static'>6</vcpu>


### PR DESCRIPTION
Upgrade was not picking up vm_name since vmname is defined in xml definition