### PR TITLE
[vrs-postdeploy] Enhanced check_vsc_registration

### DIFF
--- a/roles/vrs-postdeploy/tasks/check_vsc_registration.yml
+++ b/roles/vrs-postdeploy/tasks/check_vsc_registration.yml
@@ -3,35 +3,40 @@
 
 - name: Set JSON Query to retrieve MgmtIP for VSC({{ controller_addr }})
   set_fact:
-    ctrl_query: "*|[?control_ip=='{{controller_addr}}'].{mgmt_ip: mgmt_ip, username: vsc_user, password: vsc_password, transport: 'cli', timeout: '180' }"
+    ctrl_query: "*|[?control_ip=='{{controller_addr}}'].{host: mgmt_ip, username: vsc_user, password: vsc_password }"
 
 - name: Query host variables for VSC Controller({{ controller_addr }})
   set_fact:
-   vsc_creds: '{{ hostvars|json_query(ctrl_query)}}'
+   vsc_creds: '{{ hostvars|json_query(ctrl_query) }}'
 
 - block:
   - name: Clean known_hosts of VSC Controller on "{{ ansible_deployment_host }}"
     known_hosts:
-      name: "{{ vsc_creds[0].mgmt_ip }}"
+      name: "{{ vsc_creds[0].host }}"
       state: absent
     delegate_to: localhost
 
+  - name: Set sed-expression variable
+    set_fact:
+     sed_expr: "s/^.*src \\([0-9]\\{1,3\\}\\.[0-9]\\{1,3\\}\\.[0-9]\\{1,3\\}\\.[0-9]\\{1,3\\}\\).*/\\1/" 
+
 
   - name: Get VTEP IP address of compute server
-    shell: "ip -o route get {{ controller_addr }} | awk '{ print $5 }'"
+    shell: "ip -o route get {{ controller_addr }} | sed '{{ sed_expr }}'"
     register: ovs_vtep_ip
 
+  - debug: var=ovs_vtep_ip verbosity=1
+
   - name: Get output of 'show vswitch-controller information' on VSC ({{ controller_addr }})
-    vsc_command:
-      command: "show vswitch-controller vswitches vs-ip {{ ovs_vtep_ip.stdout }} detail"
-      mgmt_ip: "{{ vsc_creds[0].mgmt_ip }}"
-      username: "{{ vsc_creds[0].username }}"
-      password: "{{ vsc_creds[0].password }}"
+    sros_command:
+      commands:
+        - show vswitch-controller vswitches vs-ip {{ ovs_vtep_ip.stdout }} detail
+      provider: "{{ vsc_creds[0] }}"
     delegate_to: localhost
     register: vsc_vsw_info
 
   - name: Assert that VRS has been registered properly
     assert:
-      that: "'Cntrl. Conn. state         : ready' in vsc_vsw_info.result"
+      that: "'Cntrl. Conn. state         : ready' in vsc_vsw_info.stdout[0]"
 
   when: vsc_creds | length == 1


### PR DESCRIPTION
- better regex to determine ovs-vtep ip in case VSC is routed via default route, or indirect route
- reverted to use of sros_command

This commit was verified on Ansible 2.4 to be working, but fails on Ansible 2.3.