### PR TITLE
Check VSD kvm host access early in upgrade process

### DIFF
--- a/roles/vsd-health/tasks/main.yml
+++ b/roles/vsd-health/tasks/main.yml
@@ -8,7 +8,7 @@
     register: ntp_status
     change_when: false
   
-  - name: Verify NTP status of {{ target_server }}
+  - name: Verify NTP status of the target server
     assert:
      that: "ntp_status.stdout|search('\\*')"
      msg: "NTP Status of {{ target_server }} not okay: {{ ntp_status.stdout }}. Quitting."


### PR DESCRIPTION
During an upgrade, the process failed after a long time due to invalid credentials.
By checking NTP on the VSD hosts early, we can implicitly verify that SSH access and become: root work
( and for upgrades: fail early )