### PR TITLE
Nsgv mac fixes bootstrapping

### DIFF
--- a/roles/build/templates/nsgv.j2
+++ b/roles/build/templates/nsgv.j2
@@ -20,7 +20,7 @@ enterprise: "{{ item.enterprise }}"
 {% if item.target_server_type | match("kvm") or item.target_server_type | match("vcenter")%}
 target_server: {{ item.target_server }}
 
-{% if nsgv_mac is defined %}
+{% if item.nsgv_mac is defined %}
 nsgv_mac: '{{ item.nsgv_mac }}'
 {% endif %}
 


### PR DESCRIPTION
MAC address of NSGV was not populated in the build, which is needed for ZFB
