### PR TITLE
Fix parameter passing and add shortcut to not require .yml extension

### DIFF
--- a/metro-ansible
+++ b/metro-ansible
@@ -6,12 +6,18 @@ set -ex
 PLAYBOOK=$1
 shift
 
+# Add .yml extension if needed
+EXTENSION="${PLAYBOOK##*.}"
+if [ "$EXTENSION" != "yml" ]; then
+  PLAYBOOK=${PLAYBOOK}.yml
+fi
+
 if [[ -a $PLAYBOOK  ]]; then
   echo "Executing $PLAYBOOK"
-  $(which ansible-playbook) -i hosts $PLAYBOOK $@
+  $(which ansible-playbook) -i hosts $PLAYBOOK "$@"
 elif [[ -a ./playbooks/$PLAYBOOK ]]; then
   echo "Executing ./playbooks/$PLAYBOOK"
-  $(which ansible-playbook) -i hosts wrapper.yml -e playbook=playbooks/$PLAYBOOK $@
+  $(which ansible-playbook) -i hosts wrapper.yml -e playbook=playbooks/$PLAYBOOK "$@"
 else
   echo "Requested Metro-Playbook could not be found"
   exit 1


### PR DESCRIPTION
Fixed parameter passing into metro-ansible launcher script so that it can accept parameters containing spaces.  Also, sneaking in a shortcut to not require the ".yml" extension when using the tool. (i.e. ./metro-ansible install_everything"