### PR TITLE
Define empty list to NONE in group_vars

### DIFF
--- a/roles/build/templates/group_vars.all.j2
+++ b/roles/build/templates/group_vars.all.j2
@@ -40,7 +40,7 @@ yum_update: {{ yum_update | default(True) }}
 yum_pin: {{ yum_pin | default(True) }}
 
 {% if osc_operations_list is defined %}
-{% if 'integrate_with_vsd' in osc_operations_list %}
+{% if 'integrate_with_vsd' in osc_operations_list | default('NONE') %}
 vsd_auth:
   username: {{ vsd_auth.username | default('NONE') }}
   password: {{ vsd_auth.password | default('NONE') }}


### PR DESCRIPTION
This PR fixes a bug. The osc_operations_list is not initialized. Hence jinja throws an error. The var is set to NONE if not defined.