### PR TITLE
Add skipping of VSTAT when iptables/firewalld rules are already in place

### DIFF
--- a/roles/check-node-reachability/tasks/main.yml
+++ b/roles/check-node-reachability/tasks/main.yml
@@ -29,15 +29,15 @@
     register: mgmt_ip_ping_result
     delegate_to: localhost
 
-  - name: Assert no response to ping of hostname
+  - name: Assert reachability of hostname is the same as management IP
     assert:
       that: "host_ping_result.rc != 0 or mgmt_ip_ping_result.rc == 0"
-      msg:  "Response received from management IP {{ mgmt_ip }} but not from hostname {{ hostname }} Quitting."
+      msg:  "Response received from hostname {{ hostname }} but not from management IP {{ mgmt_ip }}. Quitting."
 
-  - name: Assert no response to ping of IP address
+  - name: Assert reachability of management IP is the same as hostname
     assert:
       that: "host_ping_result.rc == 0 or mgmt_ip_ping_result.rc != 0"
-      msg:  "Response received from hostname {{ hostname }} but not from management IP {{ mgmt_ip }}. Quitting."
+      msg:  "Response received from management IP {{ mgmt_ip }} but not from hostname {{ hostname }} Quitting."
 
   when: not target_server_type | match("heat") or not dhcp
 

--- a/roles/vstat-deploy/tasks/non_heat.yml
+++ b/roles/vstat-deploy/tasks/non_heat.yml
@@ -55,11 +55,6 @@
     run_once: true
   when: vstat_sa_or_ha | match('ha')
 
-- name: Configure ntpd and ntpdate and local time zone
-  include_role:
-    name: common
-    tasks_from: linux-ntp-sync
-
 - block:
   - name: Resolve "{{vsd_fqdn}}"  to ip addr
     shell: host "{{vsd_fqdn}}" | awk '{print $3,$4}'
@@ -90,57 +85,78 @@
       enabled: yes
     remote_user: "root"
 
-  - name: Create iptables vars file on ansible host
-    template: src="{{ role_path }}/templates/iptables.j2" dest="/tmp/main.yml" backup=no mode=0755
-    delegate_to: "{{ ansible_deployment_host }}"
-    remote_user: "{{ ansible_sudo_username }}"
+  - name: Check if iptables is already setup for VSD rules
+    shell: iptables -L INPUT | grep 'match-set vsd src'
+    remote_user: "{{ target_server_username }}"
+    register: vstat_iptables_result
+    ignore_errors: True
 
-  - name: Include variable file.
-    include_vars: /tmp/main.yml
-    delegate_to: "{{ ansible_deployment_host }}"
-    remote_user: "{{ ansible_sudo_username }}"
+  - name: Set if skipping VSTAT deploy
+    set_fact: skip_vstat_deploy="{{ vstat_iptables_result is defined and vstat_iptables_result.rc == 0 }}"
 
-  - block:
-
-    - name: Config iptables on VSTAT vm to accept conn on ports 9200,9300 from vsd(s)
-      shell: "{{ item }}"
-      with_items:
-        - "{{ iptables_std_commands }}"
-      remote_user: "root"
-      register: iptables_results
-      ignore_errors: True
-
-    - name: Verify iptables rules installation
-      assert:
-        that: "{{ item.rc }} == 0 or
-               {{ item.stderr | search('already exists') }} or
-               {{ item.stderr | search('already added') }}"
-        msg: "iptables rule was not installed"
-      with_items:
-        - "{{ iptables_results.results }}"
-
-    when: vsd_sa_or_ha | match('sa')
+  - name: Display if skipping VSTAT deploy
+    debug:
+      msg:
+        - "***************************************************"
+        - "Skipping VSTAT deploy because it is already running"
+        - "***************************************************"
+    when: skip_vstat_deploy
 
   - block:
 
-    - name: Config iptables on VSTAT vm to accept conn on ports 9200, 9300 from vsd(s) in cluster setup
-      shell: "{{ item }}"
-      with_items:
-        - "{{ iptables_cluster_commands }}"
-      remote_user: "root"
-      register: iptables_results
-      ignore_errors: True
+    - name: Create iptables vars file on ansible host
+      template: src="{{ role_path }}/templates/iptables.j2" dest="/tmp/main.yml" backup=no mode=0755
+      delegate_to: "{{ ansible_deployment_host }}"
+      remote_user: "{{ ansible_sudo_username }}"
 
-    - name: Verify iptables rules installation
-      assert:
-        that: "{{ item.rc }} == 0 or
-               {{ item.stderr | search('already exists') }} or
-               {{ item.stderr | search('already added') }}"
-        msg: "iptables rule was not installed"
-      with_items:
-        - "{{ iptables_results.results }}"
+    - name: Include variable file.
+      include_vars: /tmp/main.yml
+      delegate_to: "{{ ansible_deployment_host }}"
+      remote_user: "{{ ansible_sudo_username }}"
 
-    when: vsd_sa_or_ha | match('ha')
+    - block:
+
+      - name: Config iptables on VSTAT vm to accept conn on ports 9200,9300 from vsd(s)
+        shell: "{{ item }}"
+        with_items:
+          - "{{ iptables_std_commands }}"
+        remote_user: "root"
+        register: iptables_results
+        ignore_errors: True
+
+      - name: Verify iptables rules installation
+        assert:
+          that: "{{ item.rc }} == 0 or
+                 {{ item.stderr | search('already exists') }} or
+                 {{ item.stderr | search('already added') }}"
+          msg: "iptables rule was not installed"
+        with_items:
+          - "{{ iptables_results.results }}"
+
+      when: vsd_sa_or_ha | match('sa')
+
+    - block:
+
+      - name: Config iptables on VSTAT vm to accept conn on ports 9200, 9300 from vsd(s) in cluster setup
+        shell: "{{ item }}"
+        with_items:
+          - "{{ iptables_cluster_commands }}"
+        remote_user: "root"
+        register: iptables_results
+        ignore_errors: True
+
+      - name: Verify iptables rules installation
+        assert:
+          that: "{{ item.rc }} == 0 or
+                 {{ item.stderr | search('already exists') }} or
+                 {{ item.stderr | search('already added') }}"
+          msg: "iptables rule was not installed"
+        with_items:
+          - "{{ iptables_results.results }}"
+
+      when: vsd_sa_or_ha | match('ha')
+
+    when: not skip_vstat_deploy
 
   when: "_svc_iptables.rc == 0"
 
@@ -163,76 +179,106 @@
       enabled: yes
     remote_user: "root"
 
-  - name: Create firewall vars file on ansible host
-    template: src="{{ role_path }}/templates/firewall.j2" dest="/tmp/main.yml" backup=no mode=0755
-    delegate_to: "{{ ansible_deployment_host }}"
-    remote_user: "{{ ansible_sudo_username }}"
+  - name: Check if firewalld is already setup for VSD rules
+    shell: firewall-cmd --list-all | grep 9200 | grep accept
+    remote_user: "{{ target_server_username }}"
+    register: vstat_firewalld_result
+    ignore_errors: True
 
-  - name: Include variable file.
-    include_vars: /tmp/main.yml
-    delegate_to: "{{ ansible_deployment_host }}"
-    remote_user: "{{ ansible_sudo_username }}"
+  - name: Set if skipping VSTAT deploy
+    set_fact: skip_vstat_deploy="{{ vstat_firewalld_result is defined and vstat_firewalld_result.rc == 0 }}"
 
-  - name: Config firewall on VSTAT vm to accept conn on ports 9200,9300 from vsd(s)
-    shell: "{{ item }}"
-    with_items:
-      - "{{ firewall_std_commands }}"
-    remote_user: "root"
-    when: vsd_sa_or_ha | match('sa')
+  - name: Display if skipping VSTAT deploy
+    debug:
+      msg:
+        - "***************************************************"
+        - "Skipping VSTAT deploy because it is already running"
+        - "***************************************************"
+    when: skip_vstat_deploy
 
-  - name: Config firewall on VSTAT vm to accept conn on ports 9200, 9300 from vsd(s) in cluster setup
-    shell: "{{ item }}"
-    with_items:
-      - "{{ firewall_cluster_commands }}"
-    when: vsd_sa_or_ha | match('ha')
-    remote_user: "root"
+  - block:
+
+    - name: Create firewall vars file on ansible host
+      template: src="{{ role_path }}/templates/firewall.j2" dest="/tmp/main.yml" backup=no mode=0755
+      delegate_to: "{{ ansible_deployment_host }}"
+      remote_user: "{{ ansible_sudo_username }}"
+
+    - name: Include variable file.
+      include_vars: /tmp/main.yml
+      delegate_to: "{{ ansible_deployment_host }}"
+      remote_user: "{{ ansible_sudo_username }}"
+
+    - name: Config firewall on VSTAT vm to accept conn on ports 9200,9300 from vsd(s)
+      shell: "{{ item }}"
+      with_items:
+        - "{{ firewall_std_commands }}"
+      remote_user: "root"
+      when: vsd_sa_or_ha | match('sa')
+
+    - name: Config firewall on VSTAT vm to accept conn on ports 9200, 9300 from vsd(s) in cluster setup
+      shell: "{{ item }}"
+      with_items:
+        - "{{ firewall_cluster_commands }}"
+      when: vsd_sa_or_ha | match('ha')
+      remote_user: "root"
+
+    when: not skip_vstat_deploy
 
   when:
     - "_svc_firewalld.rc == 0"
     - "_svc_iptables.rc != 0"
 
-- name: Restart elastic search
-  systemd:
-    name: elasticsearch
-    state: restarted
-  remote_user: "root"
+- block:
 
-- name: Execute VSTAT cluster script on standalone or clustered vsds
-  command: /opt/vsd/vsd-es-cluster-config.sh -e {{ groups['vstats'][0] }},{{ groups['vstats'][1] }},{{ groups['vstats'][2] }}
-  delegate_to: "{{ vsd_fqdn }}"
-  remote_user: root
-  environment:
-    SSHPASS: "{{ vstat_password }}"
-  run_once: true
-  when:
-    - vstat_sa_or_ha | match('ha')
-    - vsd_sa_or_ha | match('sa') or vsd_sa_or_ha | match('ha')
+  - name: Configure ntpd and ntpdate and local time zone
+    include_role:
+      name: common
+      tasks_from: linux-ntp-sync
 
-- name: Enable stats collection on standalone vsd when vstat is standalone
-  command: /opt/vsd/vsd-stats.sh -e {{ inventory_hostname }}
-  delegate_to: "{{vsd_fqdn}}"
-  remote_user: "root"
-  run_once: true
-  when:
-    - vsd_sa_or_ha | match('sa')
-    - vstat_sa_or_ha | match('sa')
+  - name: Restart elastic search
+    systemd:
+      name: elasticsearch
+      state: restarted
+    remote_user: "root"
 
-- name: Enable stats collection on the cluster vsds when vstat is standalone
-  command: /opt/vsd/vsd-stats.sh -e {{ inventory_hostname }}
-  delegate_to: "{{ item }}"
-  remote_user: "root"
-  run_once: true
-  with_items: "{{ groups['vsds'] }}"
-  when:
-    - vsd_sa_or_ha | match('ha')
-    - vstat_sa_or_ha | match('sa')
+  - name: Execute VSTAT cluster script on standalone or clustered vsds
+    command: /opt/vsd/vsd-es-cluster-config.sh -e {{ groups['vstats'][0] }},{{ groups['vstats'][1] }},{{ groups['vstats'][2] }}
+    delegate_to: "{{ vsd_fqdn }}"
+    remote_user: root
+    environment:
+      SSHPASS: "{{ vstat_password }}"
+    run_once: true
+    when:
+      - vstat_sa_or_ha | match('ha')
+      - vsd_sa_or_ha | match('sa') or vsd_sa_or_ha | match('ha')
 
-- name: Enable stats collection on the  vsd(s) when vstat is clustered
-  command: /opt/vsd/vsd-stats.sh -e {{ groups['vstats'][0] }},{{ groups['vstats'][1] }},{{ groups['vstats'][2] }}
-  delegate_to: "{{ item }}"
-  remote_user: root
-  with_items: "{{ groups['vsds'] }}"
-  run_once: true
-  when:
-    - vstat_sa_or_ha | match('ha')
-    - vsd_sa_or_ha | match('sa') or vsd_sa_or_ha | match('ha')
+  - name: Enable stats collection on standalone vsd when vstat is standalone
+    command: /opt/vsd/vsd-stats.sh -e {{ inventory_hostname }}
+    delegate_to: "{{vsd_fqdn}}"
+    remote_user: "root"
+    run_once: true
+    when:
+      - vsd_sa_or_ha | match('sa')
+      - vstat_sa_or_ha | match('sa')
+
+  - name: Enable stats collection on the cluster vsds when vstat is standalone
+    command: /opt/vsd/vsd-stats.sh -e {{ inventory_hostname }}
+    delegate_to: "{{ item }}"
+    remote_user: "root"
+    run_once: true
+    with_items: "{{ groups['vsds'] }}"
+    when:
+      - vsd_sa_or_ha | match('ha')
+      - vstat_sa_or_ha | match('sa')
+
+  - name: Enable stats collection on the  vsd(s) when vstat is clustered
+    command: /opt/vsd/vsd-stats.sh -e {{ groups['vstats'][0] }},{{ groups['vstats'][1] }},{{ groups['vstats'][2] }}
+    delegate_to: "{{ item }}"
+    remote_user: root
+    with_items: "{{ groups['vsds'] }}"
+    run_once: true
+    when:
+      - vstat_sa_or_ha | match('ha')
+      - vsd_sa_or_ha | match('sa') or vsd_sa_or_ha | match('ha')
+
+  when: not skip_vstat_deploy


### PR DESCRIPTION
Check if the iptables/firewall rules are already applied for VSTAT.  If they are, skip the remaining steps.