### PR TITLE
Workaround a bug in Ansible where autostart is ignored when 'state' is defined

### DIFF
--- a/roles/vsc-predeploy/tasks/kvm.yml
+++ b/roles/vsc-predeploy/tasks/kvm.yml
@@ -117,6 +117,7 @@
 - name: Define VSC guest VM
   virt: name={{ vmname }}
         command=define
+        autostart=True
         xml="{{ lookup('template', 'vsc.xml.j2') }}"
         uri=qemu:///system
   delegate_to: "{{ target_server }}"
@@ -125,7 +126,6 @@
 - name: Mark VSC as autostart
   virt: name={{ vmname }}
         state=running
-        autostart=True
         uri=qemu:///system
   delegate_to: "{{ target_server }}"
   remote_user: "{{ target_server_username }}"

--- a/roles/vsd-predeploy/tasks/kvm.yml
+++ b/roles/vsd-predeploy/tasks/kvm.yml
@@ -234,6 +234,7 @@
 - name: "Define new VSD VM"
   virt: name="{{ vm_name }}"
         command=define
+        autostart=True
         xml="{{ lookup('template', 'vsd.xml.j2') }}"
         uri=qemu:///system
   delegate_to: "{{ target_server }}"
@@ -242,7 +243,6 @@
 - name: "Run VSD VM"
   virt: name="{{ vm_name }}"
         state=running
-        autostart=True
         uri=qemu:///system
   delegate_to: "{{ target_server }}"
   remote_user: "{{ target_server_username }}"

--- a/roles/vsr-predeploy/tasks/kvm_define_vsr_vm.yml
+++ b/roles/vsr-predeploy/tasks/kvm_define_vsr_vm.yml
@@ -6,6 +6,7 @@
     virt:
       name: '{{ vmname }}'
       command: define
+      autostart: True
       xml: '{{ lookup("template", "vsr_xml.j2") }}'
       uri: qemu:///system
 
@@ -13,7 +14,6 @@
     virt:
       name: '{{ vmname }}'
       state: running
-      autostart: True
       uri: qemu:///system
     when: ansible_version.full | version_compare('2.3', '>=')
 


### PR DESCRIPTION
See https://github.com/ansible/ansible/blob/devel/lib/ansible/modules/cloud/misc/virt.py#L448

Happens when Ansible >= 2.3