### PR TITLE
Accept both folders and symlinks as nuage-packed/nuage-unpacked locations

### DIFF
--- a/roles/nuage-unzip/tasks/main.yml
+++ b/roles/nuage-unzip/tasks/main.yml
@@ -17,7 +17,7 @@
 
 - name: Verify that the tar.gz directory exists
   assert: {
-    that: tar_gz.stat.isdir is defined and tar_gz.stat.isdir,
+    that: tar_gz.stat.isdir is defined and tar_gz.stat.isdir or tar_gz.stat.islnk is defined and tar_gz.stat.islnk,
     msg: "{{ nuage_zipped_files_dir }} is not a valid directory"
   }
 


### PR DESCRIPTION
Currently, only directories are allowed as nuage-packed/nuage-unpacked locations. Allowing use of Symlinks is going to be useful too.