### PR TITLE
More updates required on nsgv.xml.j2 

### DIFF
--- a/roles/nsgv-predeploy/templates/nsgv.xml.j2
+++ b/roles/nsgv-predeploy/templates/nsgv.xml.j2
@@ -33,7 +33,6 @@
       <driver name='qemu' type='qcow2'/>
       <source file='{{ images_path }}/{{ vmname }}/{{ qcow2_file_name }}'/>
       <target dev='hda' bus='ide'/>
-      <alias name='ide0-0-0'/>
       <address type='drive' controller='0' bus='0' target='0' unit='0'/>
     </disk>
 {% if userdisk_path is defined %}
@@ -41,6 +40,7 @@
         <driver name='qemu' type='qcow2' cache='none'/>
         <source file='{{ userdisk_path }}'/>
         <target dev='vdb' bus="ide"/>
+        <address type='drive' controller='0' bus='0' target='0' unit='1'/>
     </disk>
 {% endif %}
 {% if bootstrap_method == 'zfb_metro' or bootstrap_method == 'zfb_external' %}
@@ -55,11 +55,7 @@
       <backingStore/>
       <target dev='hdb' bus='ide'/>
       <readonly/>
-{% if userdisk_path is defined %}
       <address type='drive' controller='0' bus='1' target='0' unit='0'/>
-{% else %}
-      <address type='drive' controller='0' bus='0' target='0' unit='1'/>
-{% endif %}
     </disk>
 {% endif %}
     <controller type='usb' index='0'>


### PR DESCRIPTION
We are guessing due to some bug on libvirt when we attach the third disk, it was trying to use the same address: `<address type='drive' controller='0' bus='0' target='0' unit='1'/>` 
for both second and third disks. Then it was failing because of address duplication, so we set the address manually. 
Second editing is we took the userdisk to second place at the sequence.