### PR TITLE
Update nsgv.xml.j2

### DIFF
--- a/roles/nsgv-predeploy/templates/nsgv.xml.j2
+++ b/roles/nsgv-predeploy/templates/nsgv.xml.j2
@@ -20,6 +20,9 @@
   <cpu>
     <topology sockets='1' cores='1' threads='1'/>
   </cpu>
+{% if userdisk_path is defined %}
+  <cpu mode='host-passthrough'/>
+{% endif %}
   <clock offset='utc'>
     <timer name='pit' tickpolicy='delay'/>
     <timer name='rtc' tickpolicy='delay'/>


### PR DESCRIPTION
we need "<cpu mode='host-passthrough'/>" this line to give capability of running vm inside the NSG. I put an if statement so we add this line only if we want to deploy a VNF capable NSG.