### PR TITLE
Update nsgv.xml.j2

### DIFF
--- a/roles/nsgv-predeploy/templates/nsgv.xml.j2
+++ b/roles/nsgv-predeploy/templates/nsgv.xml.j2
@@ -2,7 +2,6 @@
   <name>{{ vmname }}</name>
   <memory>{{ nsgv_ram }}</memory>
   <currentMemory>{{ nsgv_ram }}</currentMemory>
-  <cpu/>
   <os>
     <type arch='x86_64' machine='pc'>hvm</type>
     <smbios mode='sysinfo'/>
@@ -17,7 +16,11 @@
     <apic/>
     <acpi/>
   </features>
+{% if userdisk_path is defined %}
+  <cpu mode='host-passthrough'>
+{% else %}
   <cpu>
+{% endif %}
     <topology sockets='1' cores='1' threads='1'/>
   </cpu>
   <clock offset='utc'>


### PR DESCRIPTION
`</cpu>` tag used 2 times in the file, i deleted the first one because it was blocking the the second one.
We need `<cpu mode='host-passthrough'/>` line to give capability of running vm inside the NSG. I put an if statement so we add this line only if we want to deploy a VNF capable NSG.