### PR TITLE
Try workaround for large file fetch

### DIFF
--- a/roles/vsd-dbbackup/tasks/main.yml
+++ b/roles/vsd-dbbackup/tasks/main.yml
@@ -210,6 +210,8 @@
     src: "{{ item.files[0].path }}"
     dest: "{{ vsdbackup_dir }}"
     flat: yes
+    validate_checksum: false
+  become: false
   with_items: "{{ lst_files.results }}"
   remote_user: root
 

--- a/roles/vsr-predeploy/templates/vsr_xml.j2
+++ b/roles/vsr-predeploy/templates/vsr_xml.j2
@@ -12,7 +12,7 @@
 {% if mgmt_static_route_list is defined %}
 {% for route in mgmt_static_route_list %}{{ _static_routes.append('static-route='+route+'@'+mgmt_gateway) }}{% endfor %}
 {% endif %}
-      <entry name="product">TIMOS:slot=A chassis=VSR-I card=cpm-v mda/1=m20-v address={{ mgmt_ip }}/{{ mgmt_netmask_prefix }}@active {{ _static_routes|join(' ') }} license-file=cf3:/license.txt</entry>
+      <entry name="product">TIMOS:slot=A chassis=VSR-I card=cpm-v mda/1=m20-v address={{ (mgmt_ip + '/' + mgmt_netmask_prefix) | ipaddr() }}@active {{ _static_routes|join(' ') }} license-file=cf3:/license.txt</entry>
     </system>
   </sysinfo>
   <os>


### PR DESCRIPTION
Fetching large files has known issues with memory limitations. Perhaps a regular 'copy' would work better, this patch prevents md5 checksum calculation and remote slurp ( potentially )