### PR TITLE
Add paramiko to pip install list

### DIFF
--- a/metro-setup.sh
+++ b/metro-setup.sh
@@ -232,6 +232,7 @@ function main() {
   pip_install "pexpect"
   pip_install "vspk"
   pip_install "pyvmomi"
+  pip_install "paramiko=2.2.1"
 
   # Check for any failures and print appropriate message
   if [[ $FAILED -ne 0 ]]


### PR DESCRIPTION
Pinning paramiko version to 2.2.1 as there is a bug in the latest version (paramiko 2.3.1) installed by Ansible 2.4