### PR TITLE
Allow user to specify a global vcenter config

### DIFF
--- a/roles/build-upgrade/templates/vsc.j2
+++ b/roles/build-upgrade/templates/vsc.j2
@@ -24,11 +24,11 @@ vsc_mgmt_static_route_list:
 
 {% if item.vcenter is defined %}
 vcenter:
-  username: {{ item.vcenter.username | default('NONE') }}
-  password: {{ item.vcenter.password | default('NONE') }}
-  datacenter: {{ item.vcenter.datacenter | default('NONE') }}
-  cluster: {{ item.vcenter.cluster | default('NONE') }}
-  datastore: {{ item.vcenter.datastore | default('NONE') }}
+  username: {{ item.vcenter.username | default( vcenter.username | default('NONE')) }}
+  password: {{ item.vcenter.password | default( vcenter.password | default('NONE')) }}
+  datacenter: {{ item.vcenter.datacenter | default( vcenter.datacenter | default('NONE')) }}
+  cluster: {{ item.vcenter.cluster | default( vcenter.cluster|default('NONE')) }}
+  datastore: {{ item.vcenter.datastore | default( vcenter.datastore|default('NONE')) }}
 {% endif %}
 {% endif %}
 

--- a/roles/build-upgrade/templates/vsd.j2
+++ b/roles/build-upgrade/templates/vsd.j2
@@ -25,11 +25,11 @@ vsd_ova_path: {{ vsd_ova_path }}
 vsd_ova_file_name: {{ vsd_ova_file_name }}
 {% if item.vcenter is defined %}
 vcenter:
-  username: {{ item.vcenter.username | default('NONE') }}
-  password: {{ item.vcenter.password | default('NONE') }}
-  datacenter: {{ item.vcenter.datacenter | default('NONE') }}
-  cluster: {{ item.vcenter.cluster | default('NONE') }}
-  datastore: {{ item.vcenter.datastore | default('NONE') }}
+  username: {{ item.vcenter.username | default( vcenter.username | default('NONE')) }}
+  password: {{ item.vcenter.password | default( vcenter.password | default('NONE')) }}
+  datacenter: {{ item.vcenter.datacenter | default( vcenter.datacenter | default('NONE')) }}
+  cluster: {{ item.vcenter.cluster | default( vcenter.cluster|default('NONE')) }}
+  datastore: {{ item.vcenter.datastore | default( vcenter.datastore|default('NONE')) }}
 {% endif %}
 {% endif %}
 {% endif %}

--- a/roles/build/templates/nsgv.j2
+++ b/roles/build/templates/nsgv.j2
@@ -56,11 +56,11 @@ nsgv_ovf_path: {{ nsgv_ovf_path }}
 nsgv_ovf_file_name: {{ nsgv_ovf_file_name }}
 {% if item.vcenter is defined %}
 vcenter:
-  username: {{ item.vcenter.username | default('NONE') }}
-  password: {{ item.vcenter.password | default('NONE') }}
-  datacenter: {{ item.vcenter.datacenter | default('NONE') }}
-  cluster: {{ item.vcenter.cluster | default('NONE') }}
-  datastore: {{ item.vcenter.datastore | default('NONE') }}
+  username: {{ item.vcenter.username | default( vcenter.username | default('NONE')) }}
+  password: {{ item.vcenter.password | default( vcenter.password | default('NONE')) }}
+  datacenter: {{ item.vcenter.datacenter | default( vcenter.datacenter | default('NONE')) }}
+  cluster: {{ item.vcenter.cluster | default( vcenter.cluster|default('NONE')) }}
+  datastore: {{ item.vcenter.datastore | default( vcenter.datastore|default('NONE')) }}
 {% endif %}
 {% endif %}
 

--- a/roles/build/templates/vcin.j2
+++ b/roles/build/templates/vcin.j2
@@ -26,11 +26,11 @@ vsd_ova_path: {{ vsd_ova_path }}
 vsd_ova_file_name: {{ vsd_ova_file_name }}
 {% if item.vcenter is defined %}
 vcenter:
-  username: {{ item.vcenter.username | default('NONE') }}
-  password: {{ item.vcenter.password | default('NONE') }}
-  datacenter: {{ item.vcenter.datacenter | default('NONE') }}
-  cluster: {{ item.vcenter.cluster | default('NONE') }}
-  datastore: {{ item.vcenter.datastore | default('NONE') }}
+  username: {{ item.vcenter.username | default( vcenter.username | default('NONE')) }}
+  password: {{ item.vcenter.password | default( vcenter.password | default('NONE')) }}
+  datacenter: {{ item.vcenter.datacenter | default( vcenter.datacenter | default('NONE')) }}
+  cluster: {{ item.vcenter.cluster | default( vcenter.cluster|default('NONE')) }}
+  datastore: {{ item.vcenter.datastore | default( vcenter.datastore|default('NONE')) }}
 {% endif %}
 {% endif %}
 {% endif %}

--- a/roles/build/templates/vsc.j2
+++ b/roles/build/templates/vsc.j2
@@ -31,11 +31,11 @@ vsc_ova_path: {{ vsc_ova_path }}
 vsc_ova_file_name: {{ vsc_ova_file_name }}
 {% if item.vcenter is defined %}
 vcenter:
-  username: {{ item.vcenter.username | default('NONE') }}
-  password: {{ item.vcenter.password | default('NONE') }}
-  datacenter: {{ item.vcenter.datacenter | default('NONE') }}
-  cluster: {{ item.vcenter.cluster | default('NONE') }}
-  datastore: {{ item.vcenter.datastore | default('NONE') }}
+  username: {{ item.vcenter.username | default( vcenter.username | default('NONE')) }}
+  password: {{ item.vcenter.password | default( vcenter.password | default('NONE')) }}
+  datacenter: {{ item.vcenter.datacenter | default( vcenter.datacenter | default('NONE')) }}
+  cluster: {{ item.vcenter.cluster | default( vcenter.cluster|default('NONE')) }}
+  datastore: {{ item.vcenter.datastore | default( vcenter.datastore|default('NONE')) }}
 {% endif %}
 {% endif %}
 {% endif %}

--- a/roles/build/templates/vsd.j2
+++ b/roles/build/templates/vsd.j2
@@ -26,11 +26,11 @@ vsd_ova_path: {{ vsd_ova_path }}
 vsd_ova_file_name: {{ vsd_ova_file_name }}
 {% if item.vcenter is defined %}
 vcenter:
-  username: {{ item.vcenter.username | default('NONE') }}
-  password: {{ item.vcenter.password | default('NONE') }}
-  datacenter: {{ item.vcenter.datacenter | default('NONE') }}
-  cluster: {{ item.vcenter.cluster | default('NONE') }}
-  datastore: {{ item.vcenter.datastore | default('NONE') }}
+  username: {{ item.vcenter.username | default( vcenter.username | default('NONE')) }}
+  password: {{ item.vcenter.password | default( vcenter.password | default('NONE')) }}
+  datacenter: {{ item.vcenter.datacenter | default( vcenter.datacenter | default('NONE')) }}
+  cluster: {{ item.vcenter.cluster | default( vcenter.cluster|default('NONE')) }}
+  datastore: {{ item.vcenter.datastore | default( vcenter.datastore|default('NONE')) }}
 {% endif %}
 {% endif %}
 {% endif %}

--- a/roles/build/templates/vstat.j2
+++ b/roles/build/templates/vstat.j2
@@ -38,11 +38,11 @@ vstat_ova_or_ovf_path: {{ vstat_ova_or_ovf_path }}
 vstat_ova_or_ovf_file_name: {{ vstat_ova_or_ovf_file_name }}
 {% if item.vcenter is defined %}
 vcenter:
-  username: {{ item.vcenter.username | default('NONE') }}
-  password: {{ item.vcenter.password | default('NONE') }}
-  datacenter: {{ item.vcenter.datacenter | default('NONE') }}
-  cluster: {{ item.vcenter.cluster | default('NONE') }}
-  datastore: {{ item.vcenter.datastore | default('NONE') }}
+  username: {{ item.vcenter.username | default( vcenter.username | default('NONE')) }}
+  password: {{ item.vcenter.password | default( vcenter.password | default('NONE')) }}
+  datacenter: {{ item.vcenter.datacenter | default( vcenter.datacenter | default('NONE')) }}
+  cluster: {{ item.vcenter.cluster | default( vcenter.cluster|default('NONE')) }}
+  datastore: {{ item.vcenter.datastore | default( vcenter.datastore|default('NONE')) }}
 {% endif %}
 {% endif %}
 {% endif %}


### PR DESCRIPTION
It is currently tedious to specify different ESXi hosts for different VMs, as the vcenter config must be repeated for each separate VM

This patch allows the user to specify a global config and e.g. only override the datastore for specific VMs