### PR TITLE
Adding new lines. Fix for issue METRO-482

### DIFF
--- a/roles/build-upgrade/templates/hosts.j2
+++ b/roles/build-upgrade/templates/hosts.j2
@@ -51,12 +51,15 @@ vrss
 [vsd_node1]
 {{ myvsds[0].hostname }} {% if 'mgmt_bridge' in myvsds[0] %} mgmt_bridge={{ myvsds[0].mgmt_bridge }}
 {% endif %}
+
 [vsd_node2]
 {{ myvsds[1].hostname }} {% if 'mgmt_bridge' in myvsds[1] %} mgmt_bridge={{ myvsds[1].mgmt_bridge }}
 {% endif %}
+
 [vsd_node3] 
 {{ myvsds[2].hostname }} {% if 'mgmt_bridge' in myvsds[2] %} mgmt_bridge={{ myvsds[2].mgmt_bridge }}
 {% endif %}
+
 [vsds:children]
 vsd_node1
 vsd_node2
@@ -86,6 +89,7 @@ vsd_node3
 
 {% endif %}
 {% endfor %}
+
 [vsc_node2]
 {% for vsc in myvscs %}
 {% if vsc.role is defined and vsc.role == 'secondary' %}


### PR DESCRIPTION
The new line creates a hosts file which can be used. Here is a sample hosts file:

# *** WARNING ***
# This file is automatically generated by build.yml.
# Changes made to this file may be overwritten.
#
[local_host]
localhost ansible_connection=local

[all_servers:vars]
ansible_ssh_private_key_file = ~/.ssh/id_rsa

[all_servers:children]
vsds
vscs


[vsd_node1]
vsd1.testbed20.met
[vsd_node2]
vsd2.testbed20.met
[vsd_node3]
vsd3.testbed20.met
[vsds:children]
vsd_node1
vsd_node2
vsd_node3



[vsc_node1]
vsc1.testbed20.met
[vsc_node2]
vsc2.testbed20.met

[vscs:children]
vsc_node1
vsc_node2