### PR TITLE
Fixed vnsutil-postdeploy to run the install script with the data_fqdn

### DIFF
--- a/Documentation/RELEASE_NOTES.md
+++ b/Documentation/RELEASE_NOTES.md
@@ -11,6 +11,7 @@
 * Eliminate check for exactly 3 XMPP users
 * Allow NSGV MAC address to be set
 * Support limit on VSC system name length without limiting hostname length
+* Fixed vnsutil-postdeploy to run the install script with the data_fqdn
 ## Release 2.3.1
 ### Resolved Issues
 * Under certain conditions, VSTAT upgrade would fail because we didn't use the _upgrade_ VM name for the new VM.

--- a/roles/vnsutil-postdeploy/vars/main.yml
+++ b/roles/vnsutil-postdeploy/vars/main.yml
@@ -5,7 +5,7 @@ create_certs: "/opt/vsd/ejbca/deploy/certMgmt.sh -a generate -u proxy -c proxy -
 create_certs_404: "/opt/vsd/ejbca/deploy/certMgmt.sh -a generate -u proxy -c proxy -d {{ data_fqdn | default(inventory_hostname) }} -f pem -t server -s root@{{inventory_hostname}}:/opt/proxy/config/keys -o csp -n VSPCA"
 
 # install script
-install_cmd: "./rpms/install.sh -x {{vsd_fqdn}} -u {{inventory_hostname}}"
+install_cmd: "./rpms/install.sh -x {{vsd_fqdn}} -u {{ data_fqdn | default(inventory_hostname) }}"
 
 # Firewall rules:
 firewall_rules:


### PR DESCRIPTION
The install script was run with the mgmt FQDN which required a rerun with the data fqdn, otherwise NSG won't bootstrap.
I added the same code snippet as for create_certs where it uses the data_fqdn if specified, otherwise the inventory hostname.