### PR TITLE
Fix paramiko package in metro-setup.sh

### DIFF
--- a/metro-setup.sh
+++ b/metro-setup.sh
@@ -232,7 +232,7 @@ function main() {
   pip_install "pexpect"
   pip_install "vspk"
   pip_install "pyvmomi"
-  pip_install "paramiko=2.2.1"
+  pip_install "paramiko==2.2.1"
 
   # Check for any failures and print appropriate message
   if [[ $FAILED -ne 0 ]]


### PR DESCRIPTION
Fix the typo in metro-setup.sh so it can actually install the paramiko package.