### PR TITLE
Update dns-process-vars.yml

### DIFF
--- a/roles/common/tasks/dns-process-vars.yml
+++ b/roles/common/tasks/dns-process-vars.yml
@@ -20,7 +20,7 @@
         }
 
     - name: Copy vstat qcow2 image to dns directory
-      copy: src={{ rc_vstat_file.files[0].path | basename }} dest={{ nuage_unzipped_files_dir }}/dns/dns.qcow2 force=yes
+      copy: src={{ rc_vstat_file.files[0].path }} dest={{ nuage_unzipped_files_dir }}/dns/dns.qcow2 force=yes
 
     - name: Find name of DNS VM QCOW2 File
       find: path="{{ nuage_unzipped_files_dir }}/dns"  pattern="*.qcow2" recurse=yes


### PR DESCRIPTION
Hi,

I think there is a mistake here, since "basename" filter gets the last name of a file path, ansible can't find the image file.