### PR TITLE
Update dns.j2

### DIFF
--- a/roles/common/templates/dns.j2
+++ b/roles/common/templates/dns.j2
@@ -6,6 +6,12 @@ target_server_type: {{ item.target_server_type | default('kvm') }}
 {% if item.target_server_type | match("kvm") %}
 target_server: {{ item.target_server }}
 
+{% if item.vmname is defined %}
+vm_name: {{ item.vmname }}
+{% else %}
+vm_name: {{ item.hostname }}
+{% endif %}
+
 mgmt_ip: {{ item.mgmt_ip }}
 mgmt_gateway: {{ item.mgmt_gateway }}
 mgmt_netmask: {{ item.mgmt_netmask }}


### PR DESCRIPTION
Hi, 
vm_name parameter used here in the dns_predeploy https://github.com/nuagenetworks/nuage-metro/blob/65b7a8722cf5012cf193e3854ce844d2c4d9dc3f/roles/dns-predeploy/tasks/kvm.yml#L71 but didn't defined anywhere. 
It's used as vmname for other components inside the build_vars.yml.