### PR TITLE
fixing the user revoke task to run on vsd instead of vstat

### DIFF
--- a/roles/vstat-deploy/tasks/aar_vss_enable.yml
+++ b/roles/vstat-deploy/tasks/aar_vss_enable.yml
@@ -6,6 +6,8 @@
 
   - name: Revoke old stats cert, if any
     command: "/opt/vsd/ejbca/deploy/certMgmt.sh -a revoke -u elastic"
+    remote_user: "{{ vsd_username }}"
+    delegate_to: "{{ groups['vsds'][0] }}"
     ignore_errors: yes
 
   remote_user: "{{ vstat_username }}"


### PR DESCRIPTION
Fixing aar_vss_enable task to delegate revoke of user to vsd