### PR TITLE
hosts.j2 file doesn't allow us to deploy more than 2 VSCs

### DIFF
--- a/roles/build/templates/hosts.j2
+++ b/roles/build/templates/hosts.j2
@@ -54,7 +54,7 @@ vsd_node3
 [vscs:children]
 vsc_node1
 
-{% else %}
+{% elif myvscs|length == 2 %}
 
 [vsc_node1]
 {{ myvscs[0].hostname }} {% if 'mgmt_bridge' in myvscs[0] %} mgmt_bridge={{ myvscs[0].mgmt_bridge }}{% endif %}{% if 'data_bridge' in myvscs[0] %} data_bridge={{ myvscs[0].data_bridge }}{% endif %}
@@ -65,6 +65,12 @@ vsc_node1
 [vscs:children]
 vsc_node1
 vsc_node2
+
+{% else %}
+
+[vscs]
+{% for vsc in myvscs %}
+{{ vsc.hostname }} {% if 'mgmt_bridge' in vsc %} mgmt_bridge={{ vsc.mgmt_bridge }}{% endif %}{% if 'data_bridge' in vsc %} data_bridge={{ vsc.data_bridge }}{% endif %}
 
 {% endif %}
 


### PR DESCRIPTION
Hi Brain,

i created an issue (https://github.com/nuagenetworks/nuage-metro/issues/622) about this but i guess there was a misunderstanding, you closed it and i couldn't reopen.
I see that you're using 'vsc_node1' and 'vsc_node2' parameters in update roles. But maybe we can use a for loop if there are more than 2 VSCs.