### PR TITLE
Update hosts.j2

### DIFF
--- a/roles/build/templates/hosts.j2
+++ b/roles/build/templates/hosts.j2
@@ -71,6 +71,7 @@ vsc_node2
 [vscs]
 {% for vsc in myvscs %}
 {{ vsc.hostname }} {% if 'mgmt_bridge' in vsc %} mgmt_bridge={{ vsc.mgmt_bridge }}{% endif %}{% if 'data_bridge' in vsc %} data_bridge={{ vsc.data_bridge }}{% endif %}
+
 {% endfor %}
 
 {% endif %}


### PR DESCRIPTION
Hi Brain, 
Missing new line there, the result is all the VSCs appears on the same line. Like this:
```
[vscs]
vsc1.pod62.cats  mgmt_bridge=br0vsc2.pod62.cats  mgmt_bridge=br0vsc3.pod62.cats  mgmt_bridge=br0vsc4.pod62.cats  mgmt_bridge=br0vsc5.pod62.cats  mgmt_bridge=br0vsc6.pod62.cats  mgmt_bridge=br0
```