### PR TITLE
Update vsr_xml.j2

### DIFF
--- a/roles/vsr-predeploy/templates/vsr_xml.j2
+++ b/roles/vsr-predeploy/templates/vsr_xml.j2
@@ -12,7 +12,7 @@
 {% if mgmt_static_route_list is defined %}
 {% for route in mgmt_static_route_list %}{{ _static_routes.append('static-route='+route+'@'+mgmt_gateway) }}{% endfor %}
 {% endif %}
-      <entry name="product">TIMOS:slot=A chassis=VSR-I card=cpm-v mda/1=m20-v address={{ (mgmt_ip + '/' + mgmt_netmask_prefix) | ipaddr() }}@active {{ _static_routes|join(' ') }} license-file=cf3:/license.txt</entry>
+      <entry name="product">TIMOS:slot=A chassis=VSR-I card=cpm-v mda/1=m20-v address={{ (mgmt_ip|string + '/' + mgmt_netmask_prefix|string ) | ipaddr() }}@active {{ _static_routes|join(' ') }} license-file=cf3:/license.txt</entry>
     </system>
   </sysinfo>
   <os>


### PR DESCRIPTION
Hi,
I got this error when i try to deploy VSR because of the template. I used 'string' filter to enforce 'mgmt_ip' and 'mgmt_netmask_prefix' variables to be string.

I only edited the entry line, i don't know why it shows others.

`fatal: [vsr1.pod62.cats]: FAILED! => {"msg": "An unhandled exception occurred while running the lookup plugin 'template'. Error was a <class 'ansible.errors.AnsibleError'>, original message: Unexpected templating type error occurred on (<domain type=\"kvm\">\n  <uuid>{{ vsr_vm_uuid }}</uuid>\r\n  <name>{{ vmname }}</name>\r\n  <memory unit=\"G\">{{ vsr_memory }}</memory>\n  <vcpu>{{ vsr_vcpu }}</vcpu>\r\n  <cpu mode=\"host-model\">\n    <model fallback=\"allow\" />\n  </cpu>\r\n  <sysinfo type=\"smbios\">\n    <system>\r\n{% set _static_routes = [] %}\r\n{% if mgmt_static_route_list is defined %}\r\n{% for route in mgmt_static_route_list %}{{ _static_routes.append('static-route='+route+'@'+mgmt_gateway) }}{% endfor %}\r\n{% endif %}\r\n      <entry name=\"product\">TIMOS:slot=A chassis=VSR-I card=cpm-v mda/1=m20-v address=\"{{ (mgmt_ip + '/' + mgmt_netmask_prefix) | ipaddr() }}\"@active {{ _static_routes|join(' ') }} license-file=cf3:/license.txt</entry>\r\n    </system>\r\n  </sysinfo>\r\n  <os>\r\n    <type arch=\"x86_64\" machine=\"pc\">hvm</type>\n    <boot dev=\"hd\" />\n    <smbios mode=\"sysinfo\" />\n  </os>\r\n  <clock offset=\"utc\">\n    <timer name=\"pit\" tickpolicy=\"delay\" />\n    <timer name=\"rtc\" tickpolicy=\"catchup\" />\n    <timer name=\"hpet\" present=\"no\" />\n  </clock>\r\n  <devices>\r\n    <emulator>/usr/libexec/qemu-kvm</emulator>\r\n    <controller model=\"pci-root\" type=\"pci\" />\n    <disk device=\"disk\" type=\"file\">\n      <driver cache=\"none\" name=\"qemu\" type=\"qcow2\" />\n      <source file=\"{{ vsr_target_qcow2_file_path }}\" />\n      <target bus=\"virtio\" dev=\"hda\" />\n    </disk>\r\n    <interface type=\"bridge\">\n      <source bridge=\"{{ mgmt_to_hv_bridge }}\" />\n      <model type=\"virtio\" />\n    </interface>\r\n{% for bridge in ports_to_hv_bridges %}\r\n    <interface type=\"bridge\">\n      <source bridge=\"{{ bridge }}\" />\n      <model type=\"virtio\" />\n    </interface>\r\n{% endfor %}\n    <serial type=\"pty\">\n      <source path=\"/dev/pts/1\" />\n      <target port=\"0\" />\n      <alias name=\"serial0\" />\n    </serial>\r\n    <console tty=\"/dev/pts/1\" type=\"pty\">\n      <source path=\"/dev/pts/1\" />\n      <target port=\"0\" type=\"serial\" />\n      <alias name=\"serial0\" />\n    </console>\r\n  </devices>\r\n</domain>\r\n): coercing to Unicode: need string or buffer, int found"}`