### PR TITLE
Update main.yml

### DIFF
--- a/roles/vsc-vns-deploy/tasks/main.yml
+++ b/roles/vsc-vns-deploy/tasks/main.yml
@@ -56,13 +56,14 @@
   - name: Configure VSC
     sros_config:
       lines:
-          - configure system security tls-profile vns-tls-profile no shutdown
+          - configure system security tls-profile vns-tls-profile
           - configure vswitch-controller open-flow tls-profile vns-tls-profile
           - configure vswitch-controller xmpp tls-profile vns-tls-profile
           - configure system time ntp ntp-server
           - configure system security tls-profile vns-tls-profile own-key cf1:\{{ xmpp.username }}-Key.pem
           - configure system security tls-profile vns-tls-profile own-certificate cf1:\{{ xmpp.username }}.pem
           - configure system security tls-profile vns-tls-profile ca-certificate cf1:\{{ xmpp.username }}-CA.pem
+          - configure system security tls-profile vns-tls-profile no shutdown
       provider: "{{ vsc_creds }}"
     delegate_to: localhost
 


### PR DESCRIPTION
Hi,
tls-profile configuration should be completed before bringing it up

otherwise it gives this error: 
```
A:vsc5.pod62.cats# configure system security tls-profile "vns-tls-profile" no shutdown 
MINOR: CERTMGR #1013 incomplete configuration
```
and it stays in down state.