### PR TITLE
Wrong next-hop for the dns static routes

### DIFF
--- a/build_vars.yml
+++ b/build_vars.yml
@@ -811,6 +811,7 @@ myvcins:
 ## mydnss is a collection of parameters for the DNS.
 ## One set of parameters is required for each DNS.
 ## data_static_route list of eth1 static routes to the data networks
+## data_gateway will be used as next-hop for the data_static_routes
 ## dns_mgmt_lookup list of management dns lookup
 ## dns_data_lookup list of data dns lookup
 ## dns_mgmt name server of managment network
@@ -827,6 +828,7 @@ myvcins:
 #      data_ip: 10.167.54.3,
 #      data_subnet: 10.167.54.0,
 #      data_netmask: 255.255.255.0,
+#      data_gateway: 10.167.54.1
 #      data_static_route: [ 10.165.53.0/24, 10.165.54.0/24, 10.165.55.0/24 ],
 #      dns_server: 8.8.8.8,
 #      dns_mgmt: g5dns.mgmt.training.net.,

--- a/roles/common/templates/dns.j2
+++ b/roles/common/templates/dns.j2
@@ -18,6 +18,9 @@ mgmt_netmask: {{ item.mgmt_netmask }}
 data_ip: {{ item.data_ip }}
 data_netmask: {{ item.data_netmask }}
 data_subnet: {{ item.data_subnet }}
+{% if item.data_gateway is defined %}
+data_gateway: {{ item.data_gateway }}
+{% endif %}
 
 data_static_route: {{ item.data_static_route|to_yaml }}
 

--- a/roles/dns-predeploy/tasks/kvm.yml
+++ b/roles/dns-predeploy/tasks/kvm.yml
@@ -120,17 +120,19 @@
   - name: Remove temporary copy of network file
     file: path={{ images_path }}/{{ inventory_hostname }}/network state=absent
 
-  - name: Create a temporary copy of the network script for route-eth1 on {{ target_server }}
-    template: src=route-eth1.j2 backup=no dest={{ images_path }}/{{ inventory_hostname }}/route-eth1
+  - block:
+    - name: Create a temporary copy of the network script for route-eth1 on {{ target_server }}
+      template: src=route-eth1.j2 backup=no dest={{ images_path }}/{{ inventory_hostname }}/route-eth1
 
-  - name: Copy route-eth1 network script file to the DNS image on {{ target_server }}
-    command: guestfish --rw -a {{ guestfish_dest }} -m {{ guestfish_mount }} copy-in {{ images_path }}/{{ inventory_hostname }}/route-eth1 /etc/sysconfig/network-scripts/
+    - name: Copy route-eth1 network script file to the DNS image on {{ target_server }}
+      command: guestfish --rw -a {{ guestfish_dest }} -m {{ guestfish_mount }} copy-in {{ images_path }}/{{ inventory_hostname }}/route-eth1 /etc/sysconfig/network-scripts/
 
-  - name: Remove temporary copy of route-eth1 network script
-    file: path={{ images_path }}/{{ inventory_hostname }}/route-eth1 state=absent
+    - name: Remove temporary copy of route-eth1 network script
+      file: path={{ images_path }}/{{ inventory_hostname }}/route-eth1 state=absent
 
-  - name: Set the owner and group on the route-eth1 network script file in the DNS image
-    command: guestfish --rw -a {{ guestfish_dest }} -m {{ guestfish_mount }} chown 0 0 /etc/sysconfig/network-scripts/route-eth1
+    - name: Set the owner and group on the route-eth1 network script file in the DNS image
+      command: guestfish --rw -a {{ guestfish_dest }} -m {{ guestfish_mount }} chown 0 0 /etc/sysconfig/network-scripts/route-eth1
+    when: data_gateway is defined
 
   - name: Set the owner and group for the network hostname file on the DNS image
     command: guestfish --rw -a {{ guestfish_dest }} -m {{ guestfish_mount }} chown 0 0 /etc/sysconfig/network

--- a/roles/dns-predeploy/templates/route-eth1.j2
+++ b/roles/dns-predeploy/templates/route-eth1.j2
@@ -1,3 +1,3 @@
 {% for route in data_static_route %}
-{{ route }} via {{ data_ip }} 
+{{ route }} via {{ data_gateway }} 
 {% endfor %}


### PR DESCRIPTION
Hi,
For the dns component `data_ip` used as a next-hop, it should be `data_gateway`, otherwise all the traffic to those subnets will be black holed.
I put an if statement to build and predeploy roles, so route-eth1 file will be copied to image only if `data_gateway`is defined in build_vars.yml

