### PR TITLE
DNS qcow2 check

### DIFF
--- a/roles/common/tasks/dns-process-vars.yml
+++ b/roles/common/tasks/dns-process-vars.yml
@@ -19,8 +19,14 @@
         msg: "DNS image is taken from VSTAT, but we can't find the image path. Make sure myvstats is defined in build_vars.yml"
         }
 
+    - name: Stat the dns qcow2 file
+      stat:
+        path: "{{ nuage_unzipped_files_dir }}/dns/dns.qcow2"
+      register: qcow_file
+
     - name: Copy vstat qcow2 image to dns directory
       copy: src={{ rc_vstat_file.files[0].path }} dest={{ nuage_unzipped_files_dir }}/dns/dns.qcow2 force=yes
+      when: not qcow_file.stat.exists
 
     - name: Find name of DNS VM QCOW2 File
       find: path="{{ nuage_unzipped_files_dir }}/dns"  pattern="*.qcow2" recurse=yes


### PR DESCRIPTION
Hi Brain,
We have an NFS server where we locate all of our qcows, it's readonly for users, when a user try to install dns "Copy vstat qcow2 image to dns directory" task tries to copy the qcow even though it's already there. Can we put a check here, so if the qcow is already there it won't copy it.