### PR TITLE
import validate-build-vars task from common roles

### DIFF
--- a/playbooks/validate_build_vars.yml
+++ b/playbooks/validate_build_vars.yml
@@ -3,5 +3,7 @@
   pre_tasks:
     - name: Include build variable files
       include_vars: "{{ build_vars_file | default ('build_vars.yml') }}"
-  roles:
-    - validate-build-vars
+  tasks:
+    - include_role:
+        name: common
+        tasks_from: validate-build-vars


### PR DESCRIPTION
We hit the following issue, seems **validate-build-vars** role doesn't exist, but maybe it would be better for users to write their own playbooks for build vars validation, which means removing this one. It seems that no one uses it anyhow ?

```
ERROR! the role 'validate-build-vars' was not found in /build/workspace/NOC-VSP-deployment@2/nuage-metro/playbooks/roles:/build/workspace/NOC-VSP-deployment@2/roles:/build/workspace/NOC-VSP-deployment@2/nuage-metro/roles:/build/workspace/NOC-VSP-deployment@2/nuage-metro/playbooks



The error appears to have been in '/build/workspace/NOC-VSP-deployment@2/nuage-metro/playbooks/validate_build_vars.yml': line 7, column 7, but may

be elsewhere in the file depending on the exact syntax problem.



The offending line appears to be:



  roles:

    - validate-build-vars

      ^ here
```