### PR TITLE
Install required packages to VRS-VM

### DIFF
--- a/roles/vrs-vm-deploy/tasks/main.yml
+++ b/roles/vrs-vm-deploy/tasks/main.yml
@@ -8,6 +8,13 @@
   when: mgmt_ip is defined
   
 - block:
+  - name: Configure yum proxy
+    lineinfile:
+      dest: /etc/yum.conf
+      regexp: "^proxy="
+      line: "proxy={{ yum_proxy }}"
+    when: not yum_proxy | match('NONE')
+
   - name: Add epel repository on RedHat OS family distros
     yum_repository:
       name: epel


### PR DESCRIPTION
Hi Brain,
We saw that some of the centos qcows has older lvm packages and it's a problem when we use guestfish command, yum update resolves that problem. Also libguestfs-tools is required for guestfish.