### PR TITLE
Check if all pip packages are installed task fails

### DIFF
--- a/roles/common/tasks/check-prereq.yml
+++ b/roles/common/tasks/check-prereq.yml
@@ -34,7 +34,7 @@
     assert:
       that: "pipoutput.stdout|search('{{ item }}')"
       msg:  "Missing required package {{ item }} . Please refer to metro-setup.sh"   
-    with_lines: ./pip_requirements.txt | sed 's/==.*//'
+    with_lines:  sed 's/==.*//' pip_requirements.txt
 
   - name : Check if all yum packages are installed
     assert:


### PR DESCRIPTION
It was trying to execute the pip_requirements.txt file, I've tested the proposed changes and it is working fine. 

```
TASK [common : Check if all pip packages are installed] *****************************************************************************************************************************************************
/bin/sh: ./pip_requirements.txt: Permission denied
```