### PR TITLE
DNS name bug fix

### DIFF
--- a/roles/dns-predeploy/templates/dns.xml.j2
+++ b/roles/dns-predeploy/templates/dns.xml.j2
@@ -1,5 +1,5 @@
 <domain type='kvm'>
-  <name>{{ inventory_hostname }}</name>
+  <name>{{ vm_name }}</name>
   <memory unit='KiB'>{{ dns_ram }}</memory>
   <currentMemory unit='KiB'>{{ dns_ram }}</currentMemory>
   <vcpu placement='static'>2</vcpu>


### PR DESCRIPTION
Hi Brain,
It is my bad, while fixing dns paths i should have changed the this parameter too.  Because in this way vm defines with `inventory_hostname` and Run DNS VM task fails because it's looking for vm defined with `vm_name`.