### PR TITLE
Security groups and Keystone V3 for OpenStack playbooks

### DIFF
--- a/examples/build_vars_openstack_static_ip.yml
+++ b/examples/build_vars_openstack_static_ip.yml
@@ -52,11 +52,13 @@ dns_domain: example.com
 ##
 ##
 ## There are no default values for openstack credentials. Uncomment and update
-## when running in a vcenter environment.
+## when running in a openstack environment.
 # os_auth:
 #   username: admin
 #   password: admin
 #   project_name: demo
+#   user_domain_name: Default       ## Uncomment/Define only when using keystone v3, if not delete
+#   project_domain_name: Default    ## Uncomment/Define only when using keystone v3, if not delete
 #   auth_url: 'http://10.0.0.4:5000/v2.0'
 
 ###
@@ -128,7 +130,8 @@ myvsds:
       mgmt_interface: {
         ip: 10.104.0.200,
         network: FrontEnd,
-        subnet: FrontEnd
+        subnet: FrontEnd,
+        security_groups: [allow-icmp, deny-http]
       },
     }
   - { hostname: vsd2.example.com,
@@ -140,7 +143,8 @@ myvsds:
       mgmt_interface: {
         ip: 10.104.0.201,
         network: FrontEnd,
-        subnet: FrontEnd
+        subnet: FrontEnd,
+        security_groups: [allow-icmp, deny-http]
       },
     }
   - { hostname: vsd3.example.com,
@@ -151,8 +155,9 @@ myvsds:
       dhcp: false,
       mgmt_interface: {
         ip: 10.104.0.202,
-        network: OC_MET_FrontEnd,
-        subnet: OC_MET_FrontEnd
+        network: FrontEnd,
+        subnet: FrontEnd,
+        security_groups: [allow-icmp, deny-http]
       },
     }
 
@@ -239,13 +244,15 @@ myvscs:
       mgmt_interface: {
         ip: 10.104.0.203,
         network: FrontEnd,
-        subnet: FrontEnd
+        subnet: FrontEnd,
+        security_groups: [allow-icmp, deny-http]
       },
       control_interface: {
         ip: 10.104.1.203,
         network: BackEnd,
         subnet: BackEnd,
-        prefix: 24
+        prefix: 24,
+        security_groups: [allow-icmp, deny-http]
       },
       system_ip: 1.1.1.2,
 #      expected_num_bgp_peers: 0 ,
@@ -265,13 +272,15 @@ myvscs:
       mgmt_interface: {
         ip: 10.104.0.204,
         network: FrontEnd,
-        subnet: FrontEnd
+        subnet: FrontEnd,
+        security_groups: [allow-icmp, deny-http]
       },
       control_interface: {
         ip: 10.104.1.204,
         network: BackEnd,
         subnet: BackEnd,
-        prefix: 24
+        prefix: 24,
+        security_groups: [allow-icmp, deny-http]
       },
       system_ip: 1.1.1.3,
 #      expected_num_bgp_peers: 0 ,
@@ -348,9 +357,10 @@ myvstats:
       dhcp: false,
       vsd_fqdn: "vsd1.example.com",
       mgmt_interface: {
-        ip: 10.104.0.200,
+        ip: 10.104.0.205,
         network: FrontEnd,
-        subnet: FrontEnd
+        subnet: FrontEnd,
+        security_groups: [allow-icmp, deny-http]
       },
     }
   - { hostname: vstat2.example.com,
@@ -361,12 +371,13 @@ myvstats:
       dhcp: false,
       vsd_fqdn: "vsd1.example.com",
       mgmt_interface: {
-        ip: 10.104.0.201,
+        ip: 10.104.0.206,
         network: FrontEnd,
-        subnet: FrontEnd
+        subnet: FrontEnd,
+        security_groups: [allow-icmp, deny-http]
       },
     }
-  - { hostname: vsd3.example.com,
+  - { hostname: vstat3.example.com,
       target_server_type: heat,
       vstat_image: vstat-5.3.1,
       vstat_flavor: vstat-lite,
@@ -374,8 +385,9 @@ myvstats:
       dhcp: false,
       vsd_fqdn: "vsd1.example.com",
       mgmt_interface: {
-        ip: 10.104.0.202,
-        network: OC_MET_FrontEnd,
-        subnet: OC_MET_FrontEnd
+        ip: 10.104.0.207,
+        network: FrontEnd,
+        subnet: FrontEnd,
+        security_groups: [allow-icmp, deny-http]
       },
     }

--- a/roles/build/templates/group_vars.all.j2
+++ b/roles/build/templates/group_vars.all.j2
@@ -51,6 +51,12 @@ os_auth:
   username: {{ os_auth.username | default('NONE') }}
   password: {{ os_auth.password | default('NONE') }}
   project_name: {{ os_auth.project_name | default('NONE') }}
+{% if os_auth.user_domain_name is defined %}
+  user_domain_name: {{ os_auth.user_domain_name | default('Default') }}
+{% endif %}
+{% if os_auth.project_domain_name is defined%}
+  project_domain_name: {{ os_auth.project_domain_name | default('Default') }}
+{% endif %}
   auth_url: "{{ os_auth.auth_url | default('NONE') }}"
 {% endif %}
 
@@ -72,6 +78,6 @@ expected_bgp_admin_state: Up
 expected_bgp_oper_state: Up
 expected_xmpp_server_state: Functional
 
-{% if 'upgrade' in vsd_operations_list or 'upgrade' in vsc_operations_list or 'upgrade' in vstat_operations_list %}
+{% if nuage_upgrade is defined and nuage_upgrade %}
 metro_backup_root: "{{ metro_backup_root | default( nuage_unzipped_files_dir + "/backups" ) }}"
 {% endif %}

--- a/roles/common/templates/vsc.j2
+++ b/roles/common/templates/vsc.j2
@@ -94,12 +94,22 @@ mgmt_interface:
   ip: {{ item.mgmt_interface.ip }}
   network: {{ item.mgmt_interface.network }}
   subnet: {{ item.mgmt_interface.subnet }}
+{% if item.mgmt_interface.security_groups is defined %}
+  security_groups: {{ item.mgmt_interface.security_groups | to_yaml }}
+{% else %}
+  security_groups: [default]
+{% endif %}
 mgmt_ip: {{ item.mgmt_interface.ip }}
 
 control_interface:
   ip: {{ item.control_interface.ip }}
   network: {{ item.control_interface.network }}
   subnet: {{ item.control_interface.subnet }}
+{% if item.control_interface.security_groups is defined %}
+  security_groups: {{ item.control_interface.security_groups | to_yaml }}
+{% else %}
+  security_groups: [default]
+{% endif %}
 control_ip: {{ item.control_interface.ip }}
 control_netmask_prefix: {{ item.control_interface.prefix }}
 {% endif %}

--- a/roles/common/templates/vsd.j2
+++ b/roles/common/templates/vsd.j2
@@ -81,6 +81,11 @@ mgmt_interface:
   ip: {{ item.mgmt_interface.ip }}
   network: {{ item.mgmt_interface.network }}
   subnet: {{ item.mgmt_interface.subnet }}
+{% if item.mgmt_interface.security_groups is defined %}
+  security_groups: {{ item.mgmt_interface.security_groups | to_yaml }}
+{% else %}
+  security_groups: [default]
+{% endif %}
 mgmt_ip: {{ item.mgmt_interface.ip }}
 {% endif %}
 

--- a/roles/common/templates/vstat.j2
+++ b/roles/common/templates/vstat.j2
@@ -73,6 +73,11 @@ mgmt_interface:
   ip: {{ item.mgmt_interface.ip }}
   network: {{ item.mgmt_interface.network }}
   subnet: {{ item.mgmt_interface.subnet }}
+{% if item.mgmt_interface.security_groups is defined %}
+  security_groups: {{ item.mgmt_interface.security_groups | to_yaml }}
+{% else %}
+  security_groups: [default]
+{% endif %}
 mgmt_ip: {{ item.mgmt_interface.ip }}
 {% endif %}
 

--- a/roles/vsc-predeploy/files/heat_fixed_ip.yml
+++ b/roles/vsc-predeploy/files/heat_fixed_ip.yml
@@ -21,6 +21,7 @@ resources:
       fixed_ips:
         - ip_address: {get_param: [mgmt_interface, ip]}
           subnet: {get_param: [mgmt_interface, subnet]}
+      security_groups: {get_param: [mgmt_interface, security_groups]}
   control_port:
     type: OS::Neutron::Port
     properties:
@@ -28,7 +29,7 @@ resources:
       fixed_ips:
         - ip_address: {get_param: [control_interface, ip]}
           subnet: {get_param: [control_interface, subnet]}
-
+      security_groups: {get_param: [mgmt_interface, security_groups]}
   mycompute:
     type: OS::Nova::Server
     properties:

--- a/roles/vsd-predeploy/files/heat_fixed_ip.yml
+++ b/roles/vsd-predeploy/files/heat_fixed_ip.yml
@@ -21,6 +21,7 @@ resources:
       fixed_ips:
         - ip_address: {get_param: [mgmt_interface, ip]}
           subnet: {get_param: [mgmt_interface, subnet]}
+      security_groups: {get_param: [mgmt_interface, security_groups]}
 
   mycompute:
     type: OS::Nova::Server

--- a/roles/vstat-predeploy/files/heat_fixed_ip.yml
+++ b/roles/vstat-predeploy/files/heat_fixed_ip.yml
@@ -21,6 +21,7 @@ resources:
       fixed_ips:
         - ip_address: {get_param: [mgmt_interface, ip]}
           subnet: {get_param: [mgmt_interface, subnet]}
+      security_groups: {get_param: [mgmt_interface, security_groups]}
 
   mycompute:
     type: OS::Nova::Server


### PR DESCRIPTION
- Added support for defining security groups. Users can define the SG as a list
- Added support for using Keystone V3 for authentication/openstack credentials
- Fixed an issue where build throws an error when vsc or vstat is not defined in build_vars
- Updated example file
