### PR TITLE
Couldn't connect to hypervisor error fix

### DIFF
--- a/roles/vrs-predeploy/tasks/main.yml
+++ b/roles/vrs-predeploy/tasks/main.yml
@@ -115,5 +115,11 @@
       name: libvirt
       state: restarted
     when: ansible_os_family == "RedHat"
+    
+  - name: Restart Libvirt-bin
+    service: 
+      name: libvirt-bin
+      state: restarted
+    when: ansible_os_family == "Debian"
 
   remote_user: "{{ target_server_username }}"


### PR DESCRIPTION
Hi,

After installing the VRS, when i type any virsh command, sometimes the hypervisor gives "couldn't connect to hypervisor" error, and restarting the libvirt service solves the problem.