### PR TITLE
Couldn't connect to hypervisor error fix

### DIFF
--- a/roles/vrs-predeploy/tasks/main.yml
+++ b/roles/vrs-predeploy/tasks/main.yml
@@ -109,5 +109,10 @@
       - ansible_os_family == "Debian"
       - dkms_install
       - vrs_arch == "u14.04"
+      
+  - name: Restart Libvirt
+    service: 
+      name: libvirtd
+      state: restarted
 
   remote_user: "{{ target_server_username }}"


### PR DESCRIPTION
Hi Brain,

Sorry for the earlier PR, i fixed it. And looked for the earlier examples and tested it, i saw that we don't need that when statement, `libvirtd` works for both RedHat and Debian.