### PR TITLE
VMware NIC Connection management module

### DIFF
--- a/library/vmware_nic_connection.py
+++ b/library/vmware_nic_connection.py
@@ -1,8 +1,6 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
-# This module is also sponsored by E.T.A.I. (www.etai.fr)
-#
 # This file is part of Ansible
 #
 # Ansible is free software: you can redistribute it and/or modify


### PR DESCRIPTION
Module to connect or disconnect VMware VM network interfaces. 
Features:
- Can find a VM based on the Name or UUID
- Can connect or disconnect a NIC based on the mac
- Can connect or disconnect all NIC's of a VM together

example:
```yaml
- hosts: localhost
  gather_facts: no
  vars:
    hostname: vcenter.domain.local
    username: administrator@vsphere.local
    password: vmware1!
    validate_certs: no
    name: "test-vm"
    datacenter: "datacenter"

  tasks:
  - name: Disconnect all nics
    delegate_to: localhost
    vmware_nic_connection:
      hostname: "{{ hostname }}"
      username: "{{ username }}"
      password: "{{ password }}"
      name: "{{ name }}"
      datacenter: "{{ datacenter }}"
      state: disconnected
      all_nics: yes
      validate_certs: no
    register: vm_facts
  
  - name: Connect one nic
    delegate_to: localhost
    vmware_nic_connection:
      hostname: "{{ hostname }}"
      username: "{{ username }}"
      password: "{{ password }}"
      name: "{{ name }}"
      datacenter: "{{ datacenter }}"
      state: connected
      nic_mac: "00:50:56:a4:01:8d"
      validate_certs: no
    register: vm_facts
  
  - name: Disconnect one nic
    delegate_to: localhost
    vmware_nic_connection:
      hostname: "{{ hostname }}"
      username: "{{ username }}"
      password: "{{ password }}"
      name: "{{ name }}"
      datacenter: "{{ datacenter }}"
      state: disconnected
      nic_mac: "00:50:56:a4:01:8d"
      validate_certs: no
    register: vm_facts
  
  - name: Connect all nics
    delegate_to: localhost
    vmware_nic_connection:
      hostname: "{{ hostname }}"
      username: "{{ username }}"
      password: "{{ password }}"
      name: "{{ name }}"
      datacenter: "{{ datacenter }}"
      state: connected
      all_nics: yes
      validate_certs: no
    register: vm_facts
```

Side Note: Rather rudimentary, but works fine for its purpose.