### PR TITLE
swapped wait_for with recommended wait_for_connection

### DIFF
--- a/roles/common/tasks/wait-for-ssh.yml
+++ b/roles/common/tasks/wait-for-ssh.yml
@@ -1,9 +1,5 @@
 ---
-- name: Wait for ssh to be ready
-  local_action:
-    module: wait_for
-    port: "22"
-    host: "{{ ssh_host }}"
-    search_regex: OpenSSH
-    delay: "{{ ssh_delay_seconds | default(5) }}"
+- name: Wait for connection to be ready
+  wait_for_connection:
+    delay: "{{ ssh_delay_seconds | default(0) }}"
     timeout: "{{ ssh_timeout_seconds | default(300) }}"


### PR DESCRIPTION
This PR proposes two changes:

1. swap outdated `wait_for` module with recommended [`wait_for_connection`](https://docs.ansible.com/ansible/2.5/modules/wait_for_connection_module.html). Introduced in 2.3
2. change the delay timer to default to `0` seconds. It seems it does not do any good to delay the process by 5s by default if the VM is already booted up. Even if its not, we have a 300s timeout interval to wait for it.

The change to `wait_for_connection` brings a benefit of checking whether the connection could be made from Ansible perspective and not only that the SSH server is answering. More rationale behind this is explained here https://github.com/ansible/ansible/issues/19998

I've tested this module with vsd/vsc deployments and it worked just fine. This is a `stableinterface`, so we should be good with relying on this