### PR TITLE
Fix the metro-ansible script to exit on failure of build

### DIFF
--- a/metro-ansible
+++ b/metro-ansible
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# set -ex
+set -e
 #
 # Wrapper around ansible-playbook for the installation of Nuage components
 
@@ -84,7 +84,7 @@ fi
 
 if [ "$TAG" != "reset" ] && [ $PLAYBOOK != "build.yml" ] && [ $PLAYBOOK != "setup.yml" ] && [ $PLAYBOOK != "nuage_unzip.yml" ]; then
   echo "Populating $TAG variables"
-  ansible-playbook -i hosts handle_vars.yml "$@"
+  $(which ansible-playbook) -i hosts handle_vars.yml "$@"
 fi
 
 if [[ -a $PLAYBOOK  ]]; then


### PR DESCRIPTION
I had removed the "set -ex" to not echo garbage to the screen.  But the "-e" is actually needed to exit the script if there is an error.  Putting it back.