### PR TITLE
Remove connection local from VSD decouple

### DIFF
--- a/roles/vsd-decouple/tasks/main.yml
+++ b/roles/vsd-decouple/tasks/main.yml
@@ -1,6 +1,5 @@
 ---
 - name: Pull facts of VSD
-  connection: local
   action: setup
   remote_user: "{{ vsd_username | default(vsd_default_username) }}"
   become: "{{ 'no' if vsd_username | default(vsd_default_username) == 'root' else 'yes' }}"


### PR DESCRIPTION
No local connection is needed for VSD decouple. 