### PR TITLE
Add sections to example deployments

### DIFF
--- a/deployments/default/common.yml
+++ b/deployments/default/common.yml
@@ -9,6 +9,8 @@
 #
 nuage_unzipped_files_dir: ""
 
+##### Management Interface
+
 # < Domain Name >
 # Domain name for this deployment. E.g. company.net.
 #
@@ -18,6 +20,10 @@ dns_domain: ""
 # For clustered VSD, the XMPP FQDN for the cluster; For standalone VSD, the FQDN of the single VSD
 #
 vsd_fqdn_global: ""
+
+##########################
+
+##### Network Bridges
 
 # < Management Network Bridge >
 # Network Bridge used for the management interface of a component or the BOF interface on VSC. This will be a Distributed Virtual PortGroup (DVPG) when deploying on vCenter or a Linux network bridge when deploying on KVM. This field can be overridden by defining the management network bridge separately in the component configuration
@@ -34,6 +40,10 @@ data_bridge: ""
 #
 # access_bridge: 
 
+#####################
+
+##### Network Services
+
 # < NTP Server IP(s) >
 # List of one or more NTP server IPv4 addresses that must be in dotted-decimal format
 #
@@ -44,6 +54,8 @@ ntp_server_list: [ ]
 #
 dns_server_list: [ ]
 
+######################
+
 # < Timezone >
 # Timezone specification for the deployment
 #
@@ -53,6 +65,8 @@ dns_server_list: [ ]
 # Full path to the directory on the KVM target server where qcow2 files will be copied
 #
 # images_path: /var/lib/libvirt/images/
+
+##### vCenter Parameters
 
 # < vCenter Datacenter >
 # vCenter datacenter to deploy Nuage components
@@ -79,6 +93,8 @@ dns_server_list: [ ]
 #
 # vcenter_ovftool: /usr/bin/ovftool
 
+########################
+
 # < SSH Public Key >
 # Full path to the public key file to be injected into Nuage components to enable passwordless connectivity for configuration
 #
@@ -104,6 +120,8 @@ dns_server_list: [ ]
 #
 # branding_zip_file: 
 
+##### Yum
+
 # < Yum update >
 # Flag to indicate whether to perform a Yum update on VSD during the installation
 #
@@ -114,10 +132,14 @@ dns_server_list: [ ]
 #
 # yum_proxy: NONE
 
+#########
+
 # < Nuage Software Version >
 # Nuage software version being installed. Optional for version comparison to skip deployment of some components that have already been installed.
 #
 # nuage_software_version: 
+
+##### PoC Parameters
 
 # < VSD Disk Size >
 # Amount of VSD disk space to allocate, in GB. Valid only for KVM deployments. Note: Changing the default value is not a supported configuration.
@@ -144,6 +166,10 @@ dns_server_list: [ ]
 #
 # vstat_ram: 16777216
 
+####################
+
+##### VSD Authentication
+
 # < VSD Architect URL >
 # VSD Architect URL. Required for tasks during Upgrade, Health Checks etc
 #
@@ -154,6 +180,10 @@ dns_server_list: [ ]
 #
 # vsd_auth_enterprise: csp
 
+########################
+
+##### VCIN Authentication
+
 # < VCIN URL >
 # VCIN URL used for API interaction. Required for tasks like VRS-E upgrade (through VCIN)
 #
@@ -163,6 +193,10 @@ dns_server_list: [ ]
 # Enterprise name used for authentication with VCIN. Required for tasks like VRS-E upgrade (through VCIN)
 #
 # vcin_auth_enterprise: csp
+
+#########################
+
+##### Libnetwork
 
 # < Libnetwork scope >
 # Scope of libnetworking support; local: connectivity between containers is limited to within the local host; global: connectivity between containers may span across hosts in the cluster
@@ -184,4 +218,6 @@ dns_server_list: [ ]
 # Port portion of the URL pointing to the key-value store used for the Libnetwork cluster
 #
 # libnetwork_cluster_store_port: 8500
+
+################
 

--- a/deployments/default/credentials.yml
+++ b/deployments/default/credentials.yml
@@ -59,6 +59,8 @@
 #
 # vstat_custom_password: 
 
+##### Custom VSD Passwords
+
 # < VSD cna Password >
 # Custom VSD cna password
 #
@@ -109,6 +111,10 @@
 #
 # vsd_keyserverstore_password: 
 
+##########################
+
+##### AWS Credentials
+
 # < AWS Access key >
 # Access key for AWS
 #
@@ -118,4 +124,6 @@
 # Secret key for AWS
 #
 # aws_secret_key: 
+
+#####################
 

--- a/deployments/default/vscs.yml
+++ b/deployments/default/vscs.yml
@@ -8,6 +8,8 @@
 # VSC 1
 #
 -
+    ##### Management Network
+
     # < Hostname >
     # Hostname of the VSC instance
     #
@@ -28,6 +30,10 @@
     #
     mgmt_gateway: ""
 
+    ########################
+
+    ##### Control Network
+
     # < Control IP address >
     # The Control/Data IP address of the controller
     #
@@ -37,6 +43,8 @@
     # Control network prefix length
     #
     ctrl_ip_prefix: 0
+
+    #####################
 
     # < System IP address >
     # Required for BGP pairing with peers
@@ -58,6 +66,8 @@
     #
     # mgmt_static_route_list: [ 0.0.0.0/1, 128.0.0.0/1 ]
 
+    ##### Target Server
+
     # < Target Server type >
     # Type of hypervisor environment into which the instance will be created
     # (kvm, vcenter, heat, aws) 
@@ -69,6 +79,8 @@
     #
     target_server: ""
 
+    ###################
+
     # < Management Network Bridge >
     # Network Bridge used for the management interface of a component or the BOF interface on VSC. This will be a Distributed Virtual PortGroup (DVPG) when deploying on vCenter or a Linux network bridge when deploying on KVM. This field can be overridden by defining the management network bridge separately in the component configuration. Defaults to the global setting
     #
@@ -78,6 +90,8 @@
     # FQDN of the VSD or VSD cluster for this VSC
     #
     # vsd_fqdn: ""
+
+    ##### vCenter Parameters
 
     # < vCenter Datacenter Name >
     # Name of the vCenter Datacenter on which the VSC VM will be deployed. Defaults to the common vCenter Datacenter Name if not defined here.
@@ -93,6 +107,10 @@
     # Name of the vCenter Datastore on which the VSC VM will be deployed. Defaults to the common vCenter Datastore Name if not defined here.
     #
     # vcenter_datastore: (global vCenter Datastore Name)
+
+    ########################
+
+    ##### Health Parameters
 
     # < Expected number of BGP neighbors >
     # Used in postdeploy and health workflows as expected values if non-zero
@@ -119,6 +137,10 @@
     #
     # expected_num_gateway_ports: 0
 
+    #######################
+
+    ##### AWS Parameters
+
     # < Private Management IP >
     # Private Management IP Address of VSC Instances on AWS
     #
@@ -138,4 +160,6 @@
     # Control IP Address of VSC Instances on AWS
     #
     # internal_ctrl_ip: ""
+
+    ####################
 

--- a/deployments/default/vsds.yml
+++ b/deployments/default/vsds.yml
@@ -8,6 +8,8 @@
 # VSD 1
 #
 -
+    ##### Management Interface
+
     # < Hostname >
     # VSD Hostname
     #
@@ -28,6 +30,8 @@
     #
     mgmt_gateway: ""
 
+    ##########################
+
     # < VM name >
     # Name of the Virtual Machine on the Hypervisor
     #
@@ -37,6 +41,8 @@
     # Virtual Machine name of the new VSD. Used during Upgrade only
     #
     # upgrade_vmname: ""
+
+    ##### Target Server
 
     # < Target Server Type >
     # Type of hypervisor environment into which the instance will be created
@@ -49,10 +55,14 @@
     #
     target_server: ""
 
+    ###################
+
     # < Management Network Bridge >
     # Network Bridge used for the management interface of a component or the BOF interface on VSC. This will be a Distributed Virtual PortGroup (DVPG) when deploying on vCenter or a Linux network bridge when deploying on KVM. This field can be overridden by defining the management network bridge separately in the component configuration. Defaults to the global setting
     #
     # mgmt_bridge: (global Bridge interface)
+
+    ##### vCenter Parameters
 
     # < vCenter Datacenter Name >
     # Name of the vCenter Datacenter on which the VSD VM will be deployed. Defaults to the common vCenter Datacenter Name if not defined here.
@@ -68,6 +78,10 @@
     # Name of the vCenter Datastore on which the VSD VM will be deployed. Defaults to the common vCenter Datastore Name if not defined here.
     #
     # vcenter_datastore: (global vCenter Datastore Name)
+
+    ########################
+
+    ##### AWS Parameters
 
     # < AWS Region >
     # Only applicable for AWS deployments
@@ -98,4 +112,6 @@
     # ENI ID for VSD Instance on Management Subnet
     #
     # aws_mgmt_eni: ""
+
+    ####################
 

--- a/deployments/default/vstats.yml
+++ b/deployments/default/vstats.yml
@@ -8,6 +8,8 @@
 # VSTAT 1
 #
 -
+    ##### Management Interface
+
     # < Hostname >
     # Management network host name for the VSTAT
     #
@@ -28,6 +30,8 @@
     #
     mgmt_gateway: ""
 
+    ##########################
+
     # < VM name >
     # Name of the Virtual Machine on the Hypervisor
     #
@@ -37,6 +41,8 @@
     # Virtual Machine name of the new Stats VM. Used during Upgrade only
     #
     # upgrade_vmname: ""
+
+    ##### Target Server
 
     # < Target Server type >
     # Type of hypervisor environment into which the instance will be created
@@ -49,6 +55,8 @@
     #
     target_server: ""
 
+    ###################
+
     # < Management Network Bridge >
     # Network Bridge used for the management interface of a component or the BOF interface on VSC. This will be a Distributed Virtual PortGroup (DVPG) when deploying on vCenter or a Linux network bridge when deploying on KVM. This field can be overridden by defining the management network bridge separately in the component configuration. Defaults to the global setting
     #
@@ -58,6 +66,8 @@
     # FQDN of the VSD or VSD cluster for this VSTAT
     #
     # vsd_fqdn: 
+
+    ##### vCenter Parameters
 
     # < vCenter Datacenter Name >
     # Name of the vCenter Datacenter on which the VSTAT VM will be deployed. Defaults to the common vCenter Datacenter Name if not defined here.
@@ -69,10 +79,14 @@
     #
     # vcenter_cluster: (global vCenter Cluster Name)
 
+    ##### vCenter Parameters
+
     # < vCenter Datastore Name >
     # Name of the vCenter Datastore on which the VSTAT VM will be deployed. Defaults to the common vCenter Datastore Name if not defined here.
     #
     # vcenter_datastore: (global vCenter Datastore Name)
+
+    ##### AWS Parameters
 
     # < AWS AMI ID >
     # AMI ID for AWS instance
@@ -98,4 +112,6 @@
     # ENI ID for VSTAT Instance on Management Subnetwork
     #
     # aws_mgmt_eni: ""
+
+    ####################
 

--- a/examples/aws_sdwan_install/common.yml
+++ b/examples/aws_sdwan_install/common.yml
@@ -11,6 +11,8 @@
 #
 nuage_unzipped_files_dir: "/my/unzipped/filedir"
 
+##### Management Interface
+
 # < Domain Name >
 # Domain name for this deployment. E.g. company.net.
 #
@@ -20,6 +22,10 @@ dns_domain: "company.com"
 # For clustered VSD, the XMPP FQDN for the cluster; For standalone VSD, the FQDN of the single VSD
 #
 vsd_fqdn_global: "vsd1.company.com"
+
+##########################
+
+##### Network Bridges
 
 # < Management Network Bridge >
 # Network Bridge used for the management interface of a component or the BOF interface on VSC. This will be a Distributed Virtual PortGroup (DVPG) when deploying on vCenter or a Linux network bridge when deploying on KVM. This field can be overridden by defining the management network bridge separately in the component configuration
@@ -36,6 +42,10 @@ data_bridge: "192.168.110.2"
 #
 # access_bridge:
 
+#####################
+
+##### Network Services
+
 # < NTP Server IP(s) >
 # List of one or more NTP server IPv4 addresses that must be in dotted-decimal format
 #
@@ -46,6 +56,8 @@ ntp_server_list: [ "5.5.5.5", "2.2.2.2", ]
 #
 dns_server_list: [ "10.1.0.2", ]
 
+######################
+
 # < Timezone >
 # Timezone specification for the deployment
 #
@@ -55,6 +67,8 @@ dns_server_list: [ "10.1.0.2", ]
 # Full path to the directory on the KVM target server where qcow2 files will be copied
 #
 # images_path: /var/lib/libvirt/images/
+
+##### vCenter Parameters
 
 # < vCenter Datacenter >
 # vCenter datacenter to deploy Nuage components
@@ -81,6 +95,8 @@ dns_server_list: [ "10.1.0.2", ]
 #
 # vcenter_ovftool: /usr/bin/ovftool
 
+########################
+
 # < SSH Public Key >
 # Full path to the public key file to be injected into Nuage components to enable passwordless connectivity for configuration
 #
@@ -106,6 +122,8 @@ dns_server_list: [ "10.1.0.2", ]
 #
 # branding_zip_file:
 
+##### Yum
+
 # < Yum update >
 # Flag to indicate whether to perform a Yum update on VSD during the installation
 #
@@ -116,10 +134,14 @@ dns_server_list: [ "10.1.0.2", ]
 #
 # yum_proxy: NONE
 
+#########
+
 # < Nuage Software Version >
 # Nuage software version being installed. Optional for version comparison to skip deployment of some components that have already been installed.
 #
 # nuage_software_version:
+
+##### PoC Parameters
 
 # < VSD Disk Size >
 # Amount of VSD disk space to allocate, in GB. Valid only for KVM deployments. Note: Changing the default value is not a supported configuration.
@@ -146,6 +168,10 @@ dns_server_list: [ "10.1.0.2", ]
 #
 # vstat_ram: 16777216
 
+####################
+
+##### VSD Authentication
+
 # < VSD Architect URL >
 # VSD Architect URL. Required for tasks during Upgrade, Health Checks etc
 #
@@ -156,6 +182,10 @@ dns_server_list: [ "10.1.0.2", ]
 #
 # vsd_auth_enterprise: csp
 
+########################
+
+##### VCIN Authentication
+
 # < VCIN URL >
 # VCIN URL used for API interaction. Required for tasks like VRS-E upgrade (through VCIN)
 #
@@ -165,6 +195,10 @@ dns_server_list: [ "10.1.0.2", ]
 # Enterprise name used for authentication with VCIN. Required for tasks like VRS-E upgrade (through VCIN)
 #
 # vcin_auth_enterprise: csp
+
+#########################
+
+##### Libnetwork
 
 # < Libnetwork scope >
 # Scope of libnetworking support; local: connectivity between containers is limited to within the local host; global: connectivity between containers may span across hosts in the cluster
@@ -186,3 +220,5 @@ dns_server_list: [ "10.1.0.2", ]
 # Port portion of the URL pointing to the key-value store used for the Libnetwork cluster
 #
 # libnetwork_cluster_store_port: 8500
+
+################

--- a/examples/aws_sdwan_install/credentials.yml
+++ b/examples/aws_sdwan_install/credentials.yml
@@ -61,6 +61,8 @@
 #
 # vstat_custom_password:
 
+##### Custom VSD Passwords
+
 # < VSD cna Password >
 # Custom VSD cna password
 #
@@ -111,6 +113,10 @@
 #
 # vsd_keyserverstore_password:
 
+##########################
+
+##### AWS Credentials
+
 # < AWS Access key >
 # Access key for AWS
 #
@@ -120,3 +126,5 @@ aws_access_key: "YOUR_AWS_ACCESS_KEY"
 # Secret key for AWS
 #
 aws_secret_key: "YOUR_AWS_SECRET_KEY"
+
+#####################

--- a/examples/aws_sdwan_install/vnsutils.yml
+++ b/examples/aws_sdwan_install/vnsutils.yml
@@ -12,6 +12,8 @@
 # VNSUtil 1
 #
 -
+    ##### Management Interface
+
     # < Hostname >
     # Hostname of the Proxy/Util-VM instance
     #
@@ -32,10 +34,14 @@
     #
     mgmt_gateway: "192.168.110.1"
 
+    ##########################
+
     # < VM name >
     # Name of the Virtual Machine on the Hypervisor
     #
     # vmname: (Hostname)
+
+    ##### Target Server
 
     # < Target Server Type >
     # Type of hypervisor environment into which the instance will be created
@@ -48,10 +54,14 @@
     #
     target_server: "10.105.1.107"
 
+    ###################
+
     # < Management Bridge interface >
     # Network Bridge used for the management interface of a component or the BOF interface on the VM. This will be a Distributed Virtual PortGroup (DVPG) when deploying on vCenter or a Linux network bridge (ex: br0) when deploying on KVM. This field takes precedence over the value defined in the Commons section
     #
     # mgmt_bridge: (global Bridge interface)
+
+    ##### Data Interface
 
     # < VNSUTIL Data FQDN >
     #
@@ -70,6 +80,10 @@
     #
     # data_subnet:
 
+    ####################
+
+    ##### NSGv Parameters
+
     # < NSGV IP Address >
     #
     # nsgv_ip:
@@ -81,6 +95,10 @@
     # < NSGV Hostname >
     #
     # nsgv_hostname: nsgv1.(DNS Domain)
+
+    #####################
+
+    ##### vCenter Parameters
 
     # < vCenter Datacenter Name >
     # Name of the vCenter Datacenter on which the Proxy/Util VM will be deployed. Defaults to the common vCenter Datacenter Name if not defined here.
@@ -96,6 +114,10 @@
     # Name of the vCenter Datastore on which the Proxy/Util VM will be deployed. Defaults to the common vCenter Datastore Name if not defined here.
     #
     # vcenter_datastore: (global vCenter Datastore Name)
+
+    ########################
+
+    ##### AWS Parameters
 
     # < AWS Region >
     # Only applicable for AWS deployments
@@ -126,6 +148,8 @@
     # ENI ID for VNSUTIL on Data Interface
     #
     aws_data_eni: "eni-02ce142389231fff6"
+
+    ####################
 
 
 

--- a/examples/aws_sdwan_install/vscs.yml
+++ b/examples/aws_sdwan_install/vscs.yml
@@ -12,6 +12,8 @@
 # VSC 1
 #
 -
+    ##### Management Network
+
     # < Hostname >
     # Hostname of the VSC instance
     #
@@ -32,6 +34,10 @@
     #
     mgmt_gateway: "192.168.110.1"
 
+    ########################
+
+    ##### Control Network
+
     # < Control IP address >
     # The Control/Data IP address of the controller
     #
@@ -41,6 +47,8 @@
     # Control network prefix length
     #
     ctrl_ip_prefix: 24
+
+    #####################
 
     # < System IP address >
     # Required for BGP pairing with peers
@@ -62,6 +70,8 @@
     #
     # mgmt_static_route_list: [ 0.0.0.0/1, 128.0.0.0/1 ]
 
+    ##### Target Server
+
     # < Target Server type >
     # Type of hypervisor environment into which the instance will be created
     # (kvm, vcenter, heat, aws) 
@@ -73,6 +83,8 @@
     #
     target_server: "10.105.1.100"
 
+    ###################
+
     # < Management Network Bridge >
     # Network Bridge used for the management interface of a component or the BOF interface on VSC. This will be a Distributed Virtual PortGroup (DVPG) when deploying on vCenter or a Linux network bridge when deploying on KVM. This field can be overridden by defining the management network bridge separately in the component configuration. Defaults to the global setting
     #
@@ -82,6 +94,8 @@
     # FQDN of the VSD or VSD cluster for this VSC
     #
     # vsd_fqdn: ""
+
+    ##### vCenter Parameters
 
     # < vCenter Datacenter Name >
     # Name of the vCenter Datacenter on which the VSC VM will be deployed. Defaults to the common vCenter Datacenter Name if not defined here.
@@ -97,6 +111,10 @@
     # Name of the vCenter Datastore on which the VSC VM will be deployed. Defaults to the common vCenter Datastore Name if not defined here.
     #
     # vcenter_datastore: (global vCenter Datastore Name)
+
+    ########################
+
+    ##### Health Parameters
 
     # < Expected number of BGP neighbors >
     # Used in postdeploy and health workflows as expected values if non-zero
@@ -123,6 +141,10 @@
     #
     # expected_num_gateway_ports: 0
 
+    #######################
+
+    ##### AWS Parameters
+
     # < Private Management IP >
     # Private Management IP Address of VSC Instances on AWS
     #
@@ -143,11 +165,15 @@
     #
     # internal_ctrl_ip: ""
 
+    ####################
+
 
 #
 # VSC 2
 #
 -
+    ##### Management Network
+
     # < Hostname >
     # Hostname of the VSC instance
     #
@@ -168,6 +194,10 @@
     #
     mgmt_gateway: "192.168.110.1"
 
+    ########################
+
+    ##### Control Network
+
     # < Control IP address >
     # The Control/Data IP address of the controller
     #
@@ -177,6 +207,8 @@
     # Control network prefix length
     #
     ctrl_ip_prefix: 24
+
+    #####################
 
     # < System IP address >
     # Required for BGP pairing with peers
@@ -198,6 +230,8 @@
     #
     # mgmt_static_route_list: [ 0.0.0.0/1, 128.0.0.0/1 ]
 
+    ##### Target Server
+
     # < Target Server type >
     # Type of hypervisor environment into which the instance will be created
     # (kvm, vcenter, heat, aws) 
@@ -209,6 +243,8 @@
     #
     target_server: "10.105.1.101"
 
+    ###################
+
     # < Management Network Bridge >
     # Network Bridge used for the management interface of a component or the BOF interface on VSC. This will be a Distributed Virtual PortGroup (DVPG) when deploying on vCenter or a Linux network bridge when deploying on KVM. This field can be overridden by defining the management network bridge separately in the component configuration. Defaults to the global setting
     #
@@ -218,6 +254,8 @@
     # FQDN of the VSD or VSD cluster for this VSC
     #
     # vsd_fqdn: ""
+
+    ##### vCenter Parameters
 
     # < vCenter Datacenter Name >
     # Name of the vCenter Datacenter on which the VSC VM will be deployed. Defaults to the common vCenter Datacenter Name if not defined here.
@@ -233,6 +271,10 @@
     # Name of the vCenter Datastore on which the VSC VM will be deployed. Defaults to the common vCenter Datastore Name if not defined here.
     #
     # vcenter_datastore: (global vCenter Datastore Name)
+
+    ########################
+
+    ##### Health Parameters
 
     # < Expected number of BGP neighbors >
     # Used in postdeploy and health workflows as expected values if non-zero
@@ -259,6 +301,10 @@
     #
     # expected_num_gateway_ports: 0
 
+    #######################
+
+    ##### AWS Parameters
+
     # < Private Management IP >
     # Private Management IP Address of VSC Instances on AWS
     #
@@ -278,6 +324,8 @@
     # Control IP Address of VSC Instances on AWS
     #
     # internal_ctrl_ip: ""
+
+    ####################
 
 
 

--- a/examples/aws_sdwan_install/vsds.yml
+++ b/examples/aws_sdwan_install/vsds.yml
@@ -12,6 +12,8 @@
 # VSD 1
 #
 -
+    ##### Management Interface
+
     # < Hostname >
     # VSD Hostname
     #
@@ -32,6 +34,8 @@
     #
     mgmt_gateway: "192.168.110.1"
 
+    ##########################
+
     # < VM name >
     # Name of the Virtual Machine on the Hypervisor
     #
@@ -41,6 +45,8 @@
     # Virtual Machine name of the new VSD. Used during Upgrade only
     #
     # upgrade_vmname: ""
+
+    ##### Target Server
 
     # < Target Server Type >
     # Type of hypervisor environment into which the instance will be created
@@ -53,10 +59,14 @@
     #
     target_server: "10.105.1.102"
 
+    ###################
+
     # < Management Network Bridge >
     # Network Bridge used for the management interface of a component or the BOF interface on VSC. This will be a Distributed Virtual PortGroup (DVPG) when deploying on vCenter or a Linux network bridge when deploying on KVM. This field can be overridden by defining the management network bridge separately in the component configuration. Defaults to the global setting
     #
     # mgmt_bridge: (global Bridge interface)
+
+    ##### vCenter Parameters
 
     # < vCenter Datacenter Name >
     # Name of the vCenter Datacenter on which the VSD VM will be deployed. Defaults to the common vCenter Datacenter Name if not defined here.
@@ -72,6 +82,10 @@
     # Name of the vCenter Datastore on which the VSD VM will be deployed. Defaults to the common vCenter Datastore Name if not defined here.
     #
     # vcenter_datastore: (global vCenter Datastore Name)
+
+    ########################
+
+    ##### AWS Parameters
 
     # < AWS Region >
     # Only applicable for AWS deployments
@@ -103,11 +117,15 @@
     #
     aws_mgmt_eni: "eni-02ce142389233fff6"
 
+    ####################
+
 
 #
 # VSD 2
 #
 -
+    ##### Management Interface
+
     # < Hostname >
     # VSD Hostname
     #
@@ -128,6 +146,8 @@
     #
     mgmt_gateway: "192.168.110.1"
 
+    ##########################
+
     # < VM name >
     # Name of the Virtual Machine on the Hypervisor
     #
@@ -137,6 +157,8 @@
     # Virtual Machine name of the new VSD. Used during Upgrade only
     #
     # upgrade_vmname: ""
+
+    ##### Target Server
 
     # < Target Server Type >
     # Type of hypervisor environment into which the instance will be created
@@ -149,10 +171,14 @@
     #
     target_server: "10.105.1.103"
 
+    ###################
+
     # < Management Network Bridge >
     # Network Bridge used for the management interface of a component or the BOF interface on VSC. This will be a Distributed Virtual PortGroup (DVPG) when deploying on vCenter or a Linux network bridge when deploying on KVM. This field can be overridden by defining the management network bridge separately in the component configuration. Defaults to the global setting
     #
     # mgmt_bridge: (global Bridge interface)
+
+    ##### vCenter Parameters
 
     # < vCenter Datacenter Name >
     # Name of the vCenter Datacenter on which the VSD VM will be deployed. Defaults to the common vCenter Datacenter Name if not defined here.
@@ -168,6 +194,10 @@
     # Name of the vCenter Datastore on which the VSD VM will be deployed. Defaults to the common vCenter Datastore Name if not defined here.
     #
     # vcenter_datastore: (global vCenter Datastore Name)
+
+    ########################
+
+    ##### AWS Parameters
 
     # < AWS Region >
     # Only applicable for AWS deployments
@@ -199,11 +229,15 @@
     #
     aws_mgmt_eni: "eni-02ce142389235fff6"
 
+    ####################
+
 
 #
 # VSD 3
 #
 -
+    ##### Management Interface
+
     # < Hostname >
     # VSD Hostname
     #
@@ -224,6 +258,8 @@
     #
     mgmt_gateway: "192.168.110.1"
 
+    ##########################
+
     # < VM name >
     # Name of the Virtual Machine on the Hypervisor
     #
@@ -233,6 +269,8 @@
     # Virtual Machine name of the new VSD. Used during Upgrade only
     #
     # upgrade_vmname: ""
+
+    ##### Target Server
 
     # < Target Server Type >
     # Type of hypervisor environment into which the instance will be created
@@ -245,10 +283,14 @@
     #
     target_server: "10.105.1.104"
 
+    ###################
+
     # < Management Network Bridge >
     # Network Bridge used for the management interface of a component or the BOF interface on VSC. This will be a Distributed Virtual PortGroup (DVPG) when deploying on vCenter or a Linux network bridge when deploying on KVM. This field can be overridden by defining the management network bridge separately in the component configuration. Defaults to the global setting
     #
     # mgmt_bridge: (global Bridge interface)
+
+    ##### vCenter Parameters
 
     # < vCenter Datacenter Name >
     # Name of the vCenter Datacenter on which the VSD VM will be deployed. Defaults to the common vCenter Datacenter Name if not defined here.
@@ -264,6 +306,10 @@
     # Name of the vCenter Datastore on which the VSD VM will be deployed. Defaults to the common vCenter Datastore Name if not defined here.
     #
     # vcenter_datastore: (global vCenter Datastore Name)
+
+    ########################
+
+    ##### AWS Parameters
 
     # < AWS Region >
     # Only applicable for AWS deployments
@@ -294,6 +340,8 @@
     # ENI ID for VSD Instance on Management Subnet
     #
     aws_mgmt_eni: "eni-02ce142389237fff6"
+
+    ####################
 
 
 

--- a/examples/aws_sdwan_install/vstats.yml
+++ b/examples/aws_sdwan_install/vstats.yml
@@ -12,6 +12,8 @@
 # VSTAT 1
 #
 -
+    ##### Management Interface
+
     # < Hostname >
     # Management network host name for the VSTAT
     #
@@ -32,6 +34,8 @@
     #
     mgmt_gateway: "192.168.110.1"
 
+    ##########################
+
     # < VM name >
     # Name of the Virtual Machine on the Hypervisor
     #
@@ -41,6 +45,8 @@
     # Virtual Machine name of the new Stats VM. Used during Upgrade only
     #
     # upgrade_vmname: ""
+
+    ##### Target Server
 
     # < Target Server type >
     # Type of hypervisor environment into which the instance will be created
@@ -53,6 +59,8 @@
     #
     target_server: "10.105.1.105"
 
+    ###################
+
     # < Management Network Bridge >
     # Network Bridge used for the management interface of a component or the BOF interface on VSC. This will be a Distributed Virtual PortGroup (DVPG) when deploying on vCenter or a Linux network bridge when deploying on KVM. This field can be overridden by defining the management network bridge separately in the component configuration. Defaults to the global setting
     #
@@ -62,6 +70,8 @@
     # FQDN of the VSD or VSD cluster for this VSTAT
     #
     # vsd_fqdn:
+
+    ##### vCenter Parameters
 
     # < vCenter Datacenter Name >
     # Name of the vCenter Datacenter on which the VSTAT VM will be deployed. Defaults to the common vCenter Datacenter Name if not defined here.
@@ -73,10 +83,14 @@
     #
     # vcenter_cluster: (global vCenter Cluster Name)
 
+    ##### vCenter Parameters
+
     # < vCenter Datastore Name >
     # Name of the vCenter Datastore on which the VSTAT VM will be deployed. Defaults to the common vCenter Datastore Name if not defined here.
     #
     # vcenter_datastore: (global vCenter Datastore Name)
+
+    ##### AWS Parameters
 
     # < AWS AMI ID >
     # AMI ID for AWS instance
@@ -103,11 +117,15 @@
     #
     aws_mgmt_eni: "eni-02ce142739335fff6"
 
+    ####################
+
 
 #
 # VSTAT 2
 #
 -
+    ##### Management Interface
+
     # < Hostname >
     # Management network host name for the VSTAT
     #
@@ -128,6 +146,8 @@
     #
     mgmt_gateway: "192.168.110.1"
 
+    ##########################
+
     # < VM name >
     # Name of the Virtual Machine on the Hypervisor
     #
@@ -137,6 +157,8 @@
     # Virtual Machine name of the new Stats VM. Used during Upgrade only
     #
     # upgrade_vmname: ""
+
+    ##### Target Server
 
     # < Target Server type >
     # Type of hypervisor environment into which the instance will be created
@@ -149,6 +171,8 @@
     #
     target_server: "10.105.1.106"
 
+    ###################
+
     # < Management Network Bridge >
     # Network Bridge used for the management interface of a component or the BOF interface on VSC. This will be a Distributed Virtual PortGroup (DVPG) when deploying on vCenter or a Linux network bridge when deploying on KVM. This field can be overridden by defining the management network bridge separately in the component configuration. Defaults to the global setting
     #
@@ -158,6 +182,8 @@
     # FQDN of the VSD or VSD cluster for this VSTAT
     #
     # vsd_fqdn:
+
+    ##### vCenter Parameters
 
     # < vCenter Datacenter Name >
     # Name of the vCenter Datacenter on which the VSTAT VM will be deployed. Defaults to the common vCenter Datacenter Name if not defined here.
@@ -169,10 +195,14 @@
     #
     # vcenter_cluster: (global vCenter Cluster Name)
 
+    ##### vCenter Parameters
+
     # < vCenter Datastore Name >
     # Name of the vCenter Datastore on which the VSTAT VM will be deployed. Defaults to the common vCenter Datastore Name if not defined here.
     #
     # vcenter_datastore: (global vCenter Datastore Name)
+
+    ##### AWS Parameters
 
     # < AWS AMI ID >
     # AMI ID for AWS instance
@@ -198,6 +228,8 @@
     # ENI ID for VSTAT Instance on Management Subnetwork
     #
     aws_mgmt_eni: "eni-02ce142739335fff6"
+
+    ####################
 
 
 

--- a/examples/aws_sdwan_upgrade/common.yml
+++ b/examples/aws_sdwan_upgrade/common.yml
@@ -11,6 +11,8 @@
 #
 nuage_unzipped_files_dir: "/my/unzipped/filedir"
 
+##### Management Interface
+
 # < Domain Name >
 # Domain name for this deployment. E.g. company.net.
 #
@@ -20,6 +22,10 @@ dns_domain: "company.com"
 # For clustered VSD, the XMPP FQDN for the cluster; For standalone VSD, the FQDN of the single VSD
 #
 vsd_fqdn_global: "vsd1.company.com"
+
+##########################
+
+##### Network Bridges
 
 # < Management Network Bridge >
 # Network Bridge used for the management interface of a component or the BOF interface on VSC. This will be a Distributed Virtual PortGroup (DVPG) when deploying on vCenter or a Linux network bridge when deploying on KVM. This field can be overridden by defining the management network bridge separately in the component configuration
@@ -36,6 +42,10 @@ data_bridge: "192.168.110.2"
 #
 # access_bridge:
 
+#####################
+
+##### Network Services
+
 # < NTP Server IP(s) >
 # List of one or more NTP server IPv4 addresses that must be in dotted-decimal format
 #
@@ -46,6 +56,8 @@ ntp_server_list: [ "5.5.5.5", "2.2.2.2", ]
 #
 dns_server_list: [ "10.1.0.2", ]
 
+######################
+
 # < Timezone >
 # Timezone specification for the deployment
 #
@@ -55,6 +67,8 @@ dns_server_list: [ "10.1.0.2", ]
 # Full path to the directory on the KVM target server where qcow2 files will be copied
 #
 # images_path: /var/lib/libvirt/images/
+
+##### vCenter Parameters
 
 # < vCenter Datacenter >
 # vCenter datacenter to deploy Nuage components
@@ -81,6 +95,8 @@ dns_server_list: [ "10.1.0.2", ]
 #
 # vcenter_ovftool: /usr/bin/ovftool
 
+########################
+
 # < SSH Public Key >
 # Full path to the public key file to be injected into Nuage components to enable passwordless connectivity for configuration
 #
@@ -106,6 +122,8 @@ dns_server_list: [ "10.1.0.2", ]
 #
 # branding_zip_file:
 
+##### Yum
+
 # < Yum update >
 # Flag to indicate whether to perform a Yum update on VSD during the installation
 #
@@ -116,10 +134,14 @@ dns_server_list: [ "10.1.0.2", ]
 #
 # yum_proxy: NONE
 
+#########
+
 # < Nuage Software Version >
 # Nuage software version being installed. Optional for version comparison to skip deployment of some components that have already been installed.
 #
 # nuage_software_version:
+
+##### PoC Parameters
 
 # < VSD Disk Size >
 # Amount of VSD disk space to allocate, in GB. Valid only for KVM deployments. Note: Changing the default value is not a supported configuration.
@@ -146,6 +168,10 @@ dns_server_list: [ "10.1.0.2", ]
 #
 # vstat_ram: 16777216
 
+####################
+
+##### VSD Authentication
+
 # < VSD Architect URL >
 # VSD Architect URL. Required for tasks during Upgrade, Health Checks etc
 #
@@ -156,6 +182,10 @@ dns_server_list: [ "10.1.0.2", ]
 #
 # vsd_auth_enterprise: csp
 
+########################
+
+##### VCIN Authentication
+
 # < VCIN URL >
 # VCIN URL used for API interaction. Required for tasks like VRS-E upgrade (through VCIN)
 #
@@ -165,6 +195,10 @@ dns_server_list: [ "10.1.0.2", ]
 # Enterprise name used for authentication with VCIN. Required for tasks like VRS-E upgrade (through VCIN)
 #
 # vcin_auth_enterprise: csp
+
+#########################
+
+##### Libnetwork
 
 # < Libnetwork scope >
 # Scope of libnetworking support; local: connectivity between containers is limited to within the local host; global: connectivity between containers may span across hosts in the cluster
@@ -186,3 +220,5 @@ dns_server_list: [ "10.1.0.2", ]
 # Port portion of the URL pointing to the key-value store used for the Libnetwork cluster
 #
 # libnetwork_cluster_store_port: 8500
+
+################

--- a/examples/aws_sdwan_upgrade/credentials.yml
+++ b/examples/aws_sdwan_upgrade/credentials.yml
@@ -61,6 +61,8 @@
 #
 # vstat_custom_password:
 
+##### Custom VSD Passwords
+
 # < VSD cna Password >
 # Custom VSD cna password
 #
@@ -111,6 +113,10 @@
 #
 # vsd_keyserverstore_password:
 
+##########################
+
+##### AWS Credentials
+
 # < AWS Access key >
 # Access key for AWS
 #
@@ -120,3 +126,5 @@ aws_access_key: "YOUR_AWS_ACCESS_KEY"
 # Secret key for AWS
 #
 aws_secret_key: "YOUR_AWS_SECRET_KEY"
+
+#####################

--- a/examples/aws_sdwan_upgrade/vnsutils.yml
+++ b/examples/aws_sdwan_upgrade/vnsutils.yml
@@ -12,6 +12,8 @@
 # VNSUtil 1
 #
 -
+    ##### Management Interface
+
     # < Hostname >
     # Hostname of the Proxy/Util-VM instance
     #
@@ -32,10 +34,14 @@
     #
     mgmt_gateway: "192.168.110.1"
 
+    ##########################
+
     # < VM name >
     # Name of the Virtual Machine on the Hypervisor
     #
     # vmname: (Hostname)
+
+    ##### Target Server
 
     # < Target Server Type >
     # Type of hypervisor environment into which the instance will be created
@@ -48,10 +54,14 @@
     #
     target_server: "10.105.1.107"
 
+    ###################
+
     # < Management Bridge interface >
     # Network Bridge used for the management interface of a component or the BOF interface on the VM. This will be a Distributed Virtual PortGroup (DVPG) when deploying on vCenter or a Linux network bridge (ex: br0) when deploying on KVM. This field takes precedence over the value defined in the Commons section
     #
     # mgmt_bridge: (global Bridge interface)
+
+    ##### Data Interface
 
     # < VNSUTIL Data FQDN >
     #
@@ -70,6 +80,10 @@
     #
     # data_subnet:
 
+    ####################
+
+    ##### NSGv Parameters
+
     # < NSGV IP Address >
     #
     # nsgv_ip:
@@ -81,6 +95,10 @@
     # < NSGV Hostname >
     #
     # nsgv_hostname: nsgv1.(DNS Domain)
+
+    #####################
+
+    ##### vCenter Parameters
 
     # < vCenter Datacenter Name >
     # Name of the vCenter Datacenter on which the Proxy/Util VM will be deployed. Defaults to the common vCenter Datacenter Name if not defined here.
@@ -96,6 +114,10 @@
     # Name of the vCenter Datastore on which the Proxy/Util VM will be deployed. Defaults to the common vCenter Datastore Name if not defined here.
     #
     # vcenter_datastore: (global vCenter Datastore Name)
+
+    ########################
+
+    ##### AWS Parameters
 
     # < AWS Region >
     # Only applicable for AWS deployments
@@ -126,6 +148,8 @@
     # ENI ID for VNSUTIL on Data Interface
     #
     aws_data_eni: "eni-02ce142389231fff6"
+
+    ####################
 
 
 

--- a/examples/aws_sdwan_upgrade/vscs.yml
+++ b/examples/aws_sdwan_upgrade/vscs.yml
@@ -12,6 +12,8 @@
 # VSC 1
 #
 -
+    ##### Management Network
+
     # < Hostname >
     # Hostname of the VSC instance
     #
@@ -32,6 +34,10 @@
     #
     mgmt_gateway: "192.168.110.1"
 
+    ########################
+
+    ##### Control Network
+
     # < Control IP address >
     # The Control/Data IP address of the controller
     #
@@ -41,6 +47,8 @@
     # Control network prefix length
     #
     ctrl_ip_prefix: 24
+
+    #####################
 
     # < System IP address >
     # Required for BGP pairing with peers
@@ -62,6 +70,8 @@
     #
     # mgmt_static_route_list: [ 0.0.0.0/1, 128.0.0.0/1 ]
 
+    ##### Target Server
+
     # < Target Server type >
     # Type of hypervisor environment into which the instance will be created
     # (kvm, vcenter, heat, aws) 
@@ -73,6 +83,8 @@
     #
     target_server: "10.105.1.100"
 
+    ###################
+
     # < Management Network Bridge >
     # Network Bridge used for the management interface of a component or the BOF interface on VSC. This will be a Distributed Virtual PortGroup (DVPG) when deploying on vCenter or a Linux network bridge when deploying on KVM. This field can be overridden by defining the management network bridge separately in the component configuration. Defaults to the global setting
     #
@@ -82,6 +94,8 @@
     # FQDN of the VSD or VSD cluster for this VSC
     #
     # vsd_fqdn: ""
+
+    ##### vCenter Parameters
 
     # < vCenter Datacenter Name >
     # Name of the vCenter Datacenter on which the VSC VM will be deployed. Defaults to the common vCenter Datacenter Name if not defined here.
@@ -97,6 +111,10 @@
     # Name of the vCenter Datastore on which the VSC VM will be deployed. Defaults to the common vCenter Datastore Name if not defined here.
     #
     # vcenter_datastore: (global vCenter Datastore Name)
+
+    ########################
+
+    ##### Health Parameters
 
     # < Expected number of BGP neighbors >
     # Used in postdeploy and health workflows as expected values if non-zero
@@ -123,6 +141,10 @@
     #
     # expected_num_gateway_ports: 0
 
+    #######################
+
+    ##### AWS Parameters
+
     # < Private Management IP >
     # Private Management IP Address of VSC Instances on AWS
     #
@@ -143,11 +165,15 @@
     #
     # internal_ctrl_ip: ""
 
+    ####################
+
 
 #
 # VSC 2
 #
 -
+    ##### Management Network
+
     # < Hostname >
     # Hostname of the VSC instance
     #
@@ -168,6 +194,10 @@
     #
     mgmt_gateway: "192.168.110.1"
 
+    ########################
+
+    ##### Control Network
+
     # < Control IP address >
     # The Control/Data IP address of the controller
     #
@@ -177,6 +207,8 @@
     # Control network prefix length
     #
     ctrl_ip_prefix: 24
+
+    #####################
 
     # < System IP address >
     # Required for BGP pairing with peers
@@ -198,6 +230,8 @@
     #
     # mgmt_static_route_list: [ 0.0.0.0/1, 128.0.0.0/1 ]
 
+    ##### Target Server
+
     # < Target Server type >
     # Type of hypervisor environment into which the instance will be created
     # (kvm, vcenter, heat, aws) 
@@ -209,6 +243,8 @@
     #
     target_server: "10.105.1.101"
 
+    ###################
+
     # < Management Network Bridge >
     # Network Bridge used for the management interface of a component or the BOF interface on VSC. This will be a Distributed Virtual PortGroup (DVPG) when deploying on vCenter or a Linux network bridge when deploying on KVM. This field can be overridden by defining the management network bridge separately in the component configuration. Defaults to the global setting
     #
@@ -218,6 +254,8 @@
     # FQDN of the VSD or VSD cluster for this VSC
     #
     # vsd_fqdn: ""
+
+    ##### vCenter Parameters
 
     # < vCenter Datacenter Name >
     # Name of the vCenter Datacenter on which the VSC VM will be deployed. Defaults to the common vCenter Datacenter Name if not defined here.
@@ -233,6 +271,10 @@
     # Name of the vCenter Datastore on which the VSC VM will be deployed. Defaults to the common vCenter Datastore Name if not defined here.
     #
     # vcenter_datastore: (global vCenter Datastore Name)
+
+    ########################
+
+    ##### Health Parameters
 
     # < Expected number of BGP neighbors >
     # Used in postdeploy and health workflows as expected values if non-zero
@@ -259,6 +301,10 @@
     #
     # expected_num_gateway_ports: 0
 
+    #######################
+
+    ##### AWS Parameters
+
     # < Private Management IP >
     # Private Management IP Address of VSC Instances on AWS
     #
@@ -278,6 +324,8 @@
     # Control IP Address of VSC Instances on AWS
     #
     # internal_ctrl_ip: ""
+
+    ####################
 
 
 

--- a/examples/aws_sdwan_upgrade/vsds.yml
+++ b/examples/aws_sdwan_upgrade/vsds.yml
@@ -12,6 +12,8 @@
 # VSD 1
 #
 -
+    ##### Management Interface
+
     # < Hostname >
     # VSD Hostname
     #
@@ -32,6 +34,8 @@
     #
     mgmt_gateway: "192.168.110.1"
 
+    ##########################
+
     # < VM name >
     # Name of the Virtual Machine on the Hypervisor
     #
@@ -41,6 +45,8 @@
     # Virtual Machine name of the new VSD. Used during Upgrade only
     #
     # upgrade_vmname: ""
+
+    ##### Target Server
 
     # < Target Server Type >
     # Type of hypervisor environment into which the instance will be created
@@ -53,10 +59,14 @@
     #
     target_server: "10.105.1.102"
 
+    ###################
+
     # < Management Network Bridge >
     # Network Bridge used for the management interface of a component or the BOF interface on VSC. This will be a Distributed Virtual PortGroup (DVPG) when deploying on vCenter or a Linux network bridge when deploying on KVM. This field can be overridden by defining the management network bridge separately in the component configuration. Defaults to the global setting
     #
     # mgmt_bridge: (global Bridge interface)
+
+    ##### vCenter Parameters
 
     # < vCenter Datacenter Name >
     # Name of the vCenter Datacenter on which the VSD VM will be deployed. Defaults to the common vCenter Datacenter Name if not defined here.
@@ -72,6 +82,10 @@
     # Name of the vCenter Datastore on which the VSD VM will be deployed. Defaults to the common vCenter Datastore Name if not defined here.
     #
     # vcenter_datastore: (global vCenter Datastore Name)
+
+    ########################
+
+    ##### AWS Parameters
 
     # < AWS Region >
     # Only applicable for AWS deployments
@@ -103,11 +117,15 @@
     #
     aws_mgmt_eni: "eni-02ce142389233fff6"
 
+    ####################
+
 
 #
 # VSD 2
 #
 -
+    ##### Management Interface
+
     # < Hostname >
     # VSD Hostname
     #
@@ -128,6 +146,8 @@
     #
     mgmt_gateway: "192.168.110.1"
 
+    ##########################
+
     # < VM name >
     # Name of the Virtual Machine on the Hypervisor
     #
@@ -137,6 +157,8 @@
     # Virtual Machine name of the new VSD. Used during Upgrade only
     #
     # upgrade_vmname: ""
+
+    ##### Target Server
 
     # < Target Server Type >
     # Type of hypervisor environment into which the instance will be created
@@ -149,10 +171,14 @@
     #
     target_server: "10.105.1.103"
 
+    ###################
+
     # < Management Network Bridge >
     # Network Bridge used for the management interface of a component or the BOF interface on VSC. This will be a Distributed Virtual PortGroup (DVPG) when deploying on vCenter or a Linux network bridge when deploying on KVM. This field can be overridden by defining the management network bridge separately in the component configuration. Defaults to the global setting
     #
     # mgmt_bridge: (global Bridge interface)
+
+    ##### vCenter Parameters
 
     # < vCenter Datacenter Name >
     # Name of the vCenter Datacenter on which the VSD VM will be deployed. Defaults to the common vCenter Datacenter Name if not defined here.
@@ -168,6 +194,10 @@
     # Name of the vCenter Datastore on which the VSD VM will be deployed. Defaults to the common vCenter Datastore Name if not defined here.
     #
     # vcenter_datastore: (global vCenter Datastore Name)
+
+    ########################
+
+    ##### AWS Parameters
 
     # < AWS Region >
     # Only applicable for AWS deployments
@@ -199,11 +229,15 @@
     #
     aws_mgmt_eni: "eni-02ce142389235fff6"
 
+    ####################
+
 
 #
 # VSD 3
 #
 -
+    ##### Management Interface
+
     # < Hostname >
     # VSD Hostname
     #
@@ -224,6 +258,8 @@
     #
     mgmt_gateway: "192.168.110.1"
 
+    ##########################
+
     # < VM name >
     # Name of the Virtual Machine on the Hypervisor
     #
@@ -233,6 +269,8 @@
     # Virtual Machine name of the new VSD. Used during Upgrade only
     #
     # upgrade_vmname: ""
+
+    ##### Target Server
 
     # < Target Server Type >
     # Type of hypervisor environment into which the instance will be created
@@ -245,10 +283,14 @@
     #
     target_server: "10.105.1.104"
 
+    ###################
+
     # < Management Network Bridge >
     # Network Bridge used for the management interface of a component or the BOF interface on VSC. This will be a Distributed Virtual PortGroup (DVPG) when deploying on vCenter or a Linux network bridge when deploying on KVM. This field can be overridden by defining the management network bridge separately in the component configuration. Defaults to the global setting
     #
     # mgmt_bridge: (global Bridge interface)
+
+    ##### vCenter Parameters
 
     # < vCenter Datacenter Name >
     # Name of the vCenter Datacenter on which the VSD VM will be deployed. Defaults to the common vCenter Datacenter Name if not defined here.
@@ -264,6 +306,10 @@
     # Name of the vCenter Datastore on which the VSD VM will be deployed. Defaults to the common vCenter Datastore Name if not defined here.
     #
     # vcenter_datastore: (global vCenter Datastore Name)
+
+    ########################
+
+    ##### AWS Parameters
 
     # < AWS Region >
     # Only applicable for AWS deployments
@@ -294,6 +340,8 @@
     # ENI ID for VSD Instance on Management Subnet
     #
     aws_mgmt_eni: "eni-02ce142389237fff6"
+
+    ####################
 
 
 

--- a/examples/aws_sdwan_upgrade/vstats.yml
+++ b/examples/aws_sdwan_upgrade/vstats.yml
@@ -12,6 +12,8 @@
 # VSTAT 1
 #
 -
+    ##### Management Interface
+
     # < Hostname >
     # Management network host name for the VSTAT
     #
@@ -32,6 +34,8 @@
     #
     mgmt_gateway: "192.168.110.1"
 
+    ##########################
+
     # < VM name >
     # Name of the Virtual Machine on the Hypervisor
     #
@@ -41,6 +45,8 @@
     # Virtual Machine name of the new Stats VM. Used during Upgrade only
     #
     # upgrade_vmname: ""
+
+    ##### Target Server
 
     # < Target Server type >
     # Type of hypervisor environment into which the instance will be created
@@ -53,6 +59,8 @@
     #
     target_server: "10.105.1.105"
 
+    ###################
+
     # < Management Network Bridge >
     # Network Bridge used for the management interface of a component or the BOF interface on VSC. This will be a Distributed Virtual PortGroup (DVPG) when deploying on vCenter or a Linux network bridge when deploying on KVM. This field can be overridden by defining the management network bridge separately in the component configuration. Defaults to the global setting
     #
@@ -62,6 +70,8 @@
     # FQDN of the VSD or VSD cluster for this VSTAT
     #
     # vsd_fqdn:
+
+    ##### vCenter Parameters
 
     # < vCenter Datacenter Name >
     # Name of the vCenter Datacenter on which the VSTAT VM will be deployed. Defaults to the common vCenter Datacenter Name if not defined here.
@@ -73,10 +83,14 @@
     #
     # vcenter_cluster: (global vCenter Cluster Name)
 
+    ##### vCenter Parameters
+
     # < vCenter Datastore Name >
     # Name of the vCenter Datastore on which the VSTAT VM will be deployed. Defaults to the common vCenter Datastore Name if not defined here.
     #
     # vcenter_datastore: (global vCenter Datastore Name)
+
+    ##### AWS Parameters
 
     # < AWS AMI ID >
     # AMI ID for AWS instance
@@ -103,11 +117,15 @@
     #
     aws_mgmt_eni: "eni-02ce142739335fff6"
 
+    ####################
+
 
 #
 # VSTAT 2
 #
 -
+    ##### Management Interface
+
     # < Hostname >
     # Management network host name for the VSTAT
     #
@@ -128,6 +146,8 @@
     #
     mgmt_gateway: "192.168.110.1"
 
+    ##########################
+
     # < VM name >
     # Name of the Virtual Machine on the Hypervisor
     #
@@ -137,6 +157,8 @@
     # Virtual Machine name of the new Stats VM. Used during Upgrade only
     #
     # upgrade_vmname: ""
+
+    ##### Target Server
 
     # < Target Server type >
     # Type of hypervisor environment into which the instance will be created
@@ -149,6 +171,8 @@
     #
     target_server: "10.105.1.106"
 
+    ###################
+
     # < Management Network Bridge >
     # Network Bridge used for the management interface of a component or the BOF interface on VSC. This will be a Distributed Virtual PortGroup (DVPG) when deploying on vCenter or a Linux network bridge when deploying on KVM. This field can be overridden by defining the management network bridge separately in the component configuration. Defaults to the global setting
     #
@@ -158,6 +182,8 @@
     # FQDN of the VSD or VSD cluster for this VSTAT
     #
     # vsd_fqdn:
+
+    ##### vCenter Parameters
 
     # < vCenter Datacenter Name >
     # Name of the vCenter Datacenter on which the VSTAT VM will be deployed. Defaults to the common vCenter Datacenter Name if not defined here.
@@ -169,10 +195,14 @@
     #
     # vcenter_cluster: (global vCenter Cluster Name)
 
+    ##### vCenter Parameters
+
     # < vCenter Datastore Name >
     # Name of the vCenter Datastore on which the VSTAT VM will be deployed. Defaults to the common vCenter Datastore Name if not defined here.
     #
     # vcenter_datastore: (global vCenter Datastore Name)
+
+    ##### AWS Parameters
 
     # < AWS AMI ID >
     # AMI ID for AWS instance
@@ -198,6 +228,8 @@
     # ENI ID for VSTAT Instance on Management Subnetwork
     #
     aws_mgmt_eni: "eni-02ce142739335fff6"
+
+    ####################
 
 
 

--- a/examples/blank_deployment/common.yml
+++ b/examples/blank_deployment/common.yml
@@ -9,6 +9,8 @@
 #
 nuage_unzipped_files_dir: ""
 
+##### Management Interface
+
 # < Domain Name >
 # Domain name for this deployment. E.g. company.net.
 #
@@ -18,6 +20,10 @@ dns_domain: ""
 # For clustered VSD, the XMPP FQDN for the cluster; For standalone VSD, the FQDN of the single VSD
 #
 vsd_fqdn_global: ""
+
+##########################
+
+##### Network Bridges
 
 # < Management Network Bridge >
 # Network Bridge used for the management interface of a component or the BOF interface on VSC. This will be a Distributed Virtual PortGroup (DVPG) when deploying on vCenter or a Linux network bridge when deploying on KVM. This field can be overridden by defining the management network bridge separately in the component configuration
@@ -34,6 +40,10 @@ data_bridge: ""
 #
 # access_bridge: 
 
+#####################
+
+##### Network Services
+
 # < NTP Server IP(s) >
 # List of one or more NTP server IPv4 addresses that must be in dotted-decimal format
 #
@@ -44,6 +54,8 @@ ntp_server_list: [ ]
 #
 dns_server_list: [ ]
 
+######################
+
 # < Timezone >
 # Timezone specification for the deployment
 #
@@ -53,6 +65,8 @@ dns_server_list: [ ]
 # Full path to the directory on the KVM target server where qcow2 files will be copied
 #
 # images_path: /var/lib/libvirt/images/
+
+##### vCenter Parameters
 
 # < vCenter Datacenter >
 # vCenter datacenter to deploy Nuage components
@@ -79,6 +93,8 @@ dns_server_list: [ ]
 #
 # vcenter_ovftool: /usr/bin/ovftool
 
+########################
+
 # < SSH Public Key >
 # Full path to the public key file to be injected into Nuage components to enable passwordless connectivity for configuration
 #
@@ -104,6 +120,8 @@ dns_server_list: [ ]
 #
 # branding_zip_file: 
 
+##### Yum
+
 # < Yum update >
 # Flag to indicate whether to perform a Yum update on VSD during the installation
 #
@@ -114,10 +132,14 @@ dns_server_list: [ ]
 #
 # yum_proxy: NONE
 
+#########
+
 # < Nuage Software Version >
 # Nuage software version being installed. Optional for version comparison to skip deployment of some components that have already been installed.
 #
 # nuage_software_version: 
+
+##### PoC Parameters
 
 # < VSD Disk Size >
 # Amount of VSD disk space to allocate, in GB. Valid only for KVM deployments. Note: Changing the default value is not a supported configuration.
@@ -144,6 +166,10 @@ dns_server_list: [ ]
 #
 # vstat_ram: 16777216
 
+####################
+
+##### VSD Authentication
+
 # < VSD Architect URL >
 # VSD Architect URL. Required for tasks during Upgrade, Health Checks etc
 #
@@ -154,6 +180,10 @@ dns_server_list: [ ]
 #
 # vsd_auth_enterprise: csp
 
+########################
+
+##### VCIN Authentication
+
 # < VCIN URL >
 # VCIN URL used for API interaction. Required for tasks like VRS-E upgrade (through VCIN)
 #
@@ -163,6 +193,10 @@ dns_server_list: [ ]
 # Enterprise name used for authentication with VCIN. Required for tasks like VRS-E upgrade (through VCIN)
 #
 # vcin_auth_enterprise: csp
+
+#########################
+
+##### Libnetwork
 
 # < Libnetwork scope >
 # Scope of libnetworking support; local: connectivity between containers is limited to within the local host; global: connectivity between containers may span across hosts in the cluster
@@ -184,4 +218,6 @@ dns_server_list: [ ]
 # Port portion of the URL pointing to the key-value store used for the Libnetwork cluster
 #
 # libnetwork_cluster_store_port: 8500
+
+################
 

--- a/examples/blank_deployment/credentials.yml
+++ b/examples/blank_deployment/credentials.yml
@@ -59,6 +59,8 @@
 #
 # vstat_custom_password: 
 
+##### Custom VSD Passwords
+
 # < VSD cna Password >
 # Custom VSD cna password
 #
@@ -109,6 +111,10 @@
 #
 # vsd_keyserverstore_password: 
 
+##########################
+
+##### AWS Credentials
+
 # < AWS Access key >
 # Access key for AWS
 #
@@ -118,4 +124,6 @@
 # Secret key for AWS
 #
 # aws_secret_key: 
+
+#####################
 

--- a/examples/blank_deployment/nsgvs.yml
+++ b/examples/blank_deployment/nsgvs.yml
@@ -18,6 +18,8 @@
     #
     # vmname: (Hostname)
 
+    ##### Target Server
+
     # < Target Server type >
     # Type of environment into which the NSGv will be instantiated
     # (kvm, vcenter, aws) 
@@ -28,6 +30,10 @@
     # Hostname or IP address of the hypervisor or vCenter server where the NSGv will be instantiated
     #
     target_server: ""
+
+    ###################
+
+    ##### Bootstrap Parameters
 
     # < Bootstrap Method >
     # In the current MetroAE version, NSGv bootstrapping is not supported.  Bootstrap method for the NSGv. The default is 'none' which means no bootstrap will be performed. 'zfb_metro' creates a boostrap ISO file based on the contents of the file zfb_vars.yml. 'zfb_external' is used when a 3rd-party ISO file is to be used.
@@ -50,6 +56,10 @@
     #
     # nsgv_mac: ""
 
+    ##########################
+
+    ##### vCenter Parameters
+
     # < vCenter Datacenter Name >
     # Name of the vCenter Datacenter on which the NSG VM will be deployed. Defaults to the common vCenter Datacenter Name if not defined here.
     #
@@ -64,6 +74,10 @@
     # Name of the vCenter Datastore on which the NSG VM will be deployed. Defaults to the common vCenter Datastore Name if not defined here.
     #
     # vcenter_datastore: (global vCenter Datastore Name)
+
+    ########################
+
+    ##### AWS Parameters
 
     # < AWS Region >
     # AWS Region
@@ -90,6 +104,8 @@
     #
     # aws_key_name: ""
 
+    ####################
+
     # < AWS Access ENI >
     # ENI for Access Subnetwork
     #
@@ -104,6 +120,10 @@
     # AWS WAN EIP AllocID
     #
     # aws_eip_allocid: ""
+
+    ####################
+
+    ##### AWS VPC Parameters
 
     # < AWS Provision VPC CIDR >
     # CIDR for provisioning a VPC for the NSGv on AWS
@@ -124,6 +144,10 @@
     # Private Subnet CIDR for provisioning a VPC for the NSGv on AWS
     #
     # provision_vpc_private_subnet_cidr: 
+
+    ########################
+
+    ##### NSG Zero-Factor Bootstrap Parameters for type zfb_metro
 
     # < NSG License File >
     # Path to the VSD license file on the MetroAE host to associate with the NSG
@@ -219,4 +243,6 @@
     # VLAN number of the NSG access port for the NSG
     #
     # nsg_access_port_vlan_number: 
+
+    ##############################################################
 

--- a/examples/blank_deployment/vcins.yml
+++ b/examples/blank_deployment/vcins.yml
@@ -8,6 +8,8 @@
 # VCIN 1
 #
 -
+    ##### Management Interface
+
     # < Hostname >
     # Hostname of the VCIN instance
     #
@@ -28,10 +30,14 @@
     #
     mgmt_gateway: ""
 
+    ##########################
+
     # < VM name >
     # Name of the Virtual Machine on the Hypervisor
     #
     # vmname: (Hostname)
+
+    ##### Target Server
 
     # < Target Server Type >
     # Type of hypervisor environment where VMs will be instantiated
@@ -44,10 +50,14 @@
     #
     target_server: ""
 
+    ###################
+
     # < Master VCIN hostname >
     # The FQDN or IP address of the Master VCIN in an Active/Standby deployment. Only used when this VCIN is part of an active/standby configuration. The hostname provided here must match the hostname of another VCIN in the list of VCINs for this deployment.
     #
     # master_vcin: 
+
+    ##### vCenter Parameters
 
     # < vCenter Datacenter Name >
     # Name of the vCenter Datacenter on which the VCIN VM will be deployed. Defaults to the common vCenter Datacenter Name if not defined here.
@@ -63,4 +73,6 @@
     # Name of the vCenter Datastore on which the VCIN VM will be deployed. Defaults to the common vCenter Datastore Name if not defined here.
     #
     # vcenter_datastore: (global vCenter Datastore Name)
+
+    ########################
 

--- a/examples/blank_deployment/vnsutils.yml
+++ b/examples/blank_deployment/vnsutils.yml
@@ -8,6 +8,8 @@
 # VNSUtil 1
 #
 -
+    ##### Management Interface
+
     # < Hostname >
     # Hostname of the Proxy/Util-VM instance
     #
@@ -28,10 +30,14 @@
     #
     mgmt_gateway: ""
 
+    ##########################
+
     # < VM name >
     # Name of the Virtual Machine on the Hypervisor
     #
     # vmname: (Hostname)
+
+    ##### Target Server
 
     # < Target Server Type >
     # Type of hypervisor environment into which the instance will be created
@@ -44,10 +50,14 @@
     #
     target_server: ""
 
+    ###################
+
     # < Management Bridge interface >
     # Network Bridge used for the management interface of a component or the BOF interface on the VM. This will be a Distributed Virtual PortGroup (DVPG) when deploying on vCenter or a Linux network bridge (ex: br0) when deploying on KVM. This field takes precedence over the value defined in the Commons section
     #
     # mgmt_bridge: (global Bridge interface)
+
+    ##### Data Interface
 
     # < VNSUTIL Data FQDN >
     #
@@ -66,6 +76,10 @@
     #
     # data_subnet: 
 
+    ####################
+
+    ##### NSGv Parameters
+
     # < NSGV IP Address >
     #
     # nsgv_ip: 
@@ -77,6 +91,10 @@
     # < NSGV Hostname >
     #
     # nsgv_hostname: nsgv1.(DNS Domain)
+
+    #####################
+
+    ##### vCenter Parameters
 
     # < vCenter Datacenter Name >
     # Name of the vCenter Datacenter on which the Proxy/Util VM will be deployed. Defaults to the common vCenter Datacenter Name if not defined here.
@@ -92,6 +110,10 @@
     # Name of the vCenter Datastore on which the Proxy/Util VM will be deployed. Defaults to the common vCenter Datastore Name if not defined here.
     #
     # vcenter_datastore: (global vCenter Datastore Name)
+
+    ########################
+
+    ##### AWS Parameters
 
     # < AWS Region >
     # Only applicable for AWS deployments
@@ -122,4 +144,6 @@
     # ENI ID for VNSUTIL on Data Interface
     #
     # aws_data_eni: ""
+
+    ####################
 

--- a/examples/blank_deployment/vrss.yml
+++ b/examples/blank_deployment/vrss.yml
@@ -8,6 +8,8 @@
 # VRS 1
 #
 -
+    ##### Compute Nodes
+
     # < VRS Hypervisor OS type >
     # Hypervisor type for VRS installation
     # (u16.04, el7) 
@@ -19,6 +21,10 @@
     #
     vrs_ip_list: [ ]
 
+    ###################
+
+    ##### Controller Configuration
+
     # < Active Controller IP address >
     # Primary/Active Controller IP address
     #
@@ -28,6 +34,8 @@
     # Secondary/Standby Controller IP address
     #
     # standby_controller_ip: ""
+
+    ##############################
 
     # < DKMS install >
     # Optional DKMS module installation for MPLSoGRE tunnel type

--- a/examples/blank_deployment/vscs.yml
+++ b/examples/blank_deployment/vscs.yml
@@ -8,6 +8,8 @@
 # VSC 1
 #
 -
+    ##### Management Network
+
     # < Hostname >
     # Hostname of the VSC instance
     #
@@ -28,6 +30,10 @@
     #
     mgmt_gateway: ""
 
+    ########################
+
+    ##### Control Network
+
     # < Control IP address >
     # The Control/Data IP address of the controller
     #
@@ -37,6 +43,8 @@
     # Control network prefix length
     #
     ctrl_ip_prefix: 0
+
+    #####################
 
     # < System IP address >
     # Required for BGP pairing with peers
@@ -58,6 +66,8 @@
     #
     # mgmt_static_route_list: [ 0.0.0.0/1, 128.0.0.0/1 ]
 
+    ##### Target Server
+
     # < Target Server type >
     # Type of hypervisor environment into which the instance will be created
     # (kvm, vcenter, heat, aws) 
@@ -69,6 +79,8 @@
     #
     target_server: ""
 
+    ###################
+
     # < Management Network Bridge >
     # Network Bridge used for the management interface of a component or the BOF interface on VSC. This will be a Distributed Virtual PortGroup (DVPG) when deploying on vCenter or a Linux network bridge when deploying on KVM. This field can be overridden by defining the management network bridge separately in the component configuration. Defaults to the global setting
     #
@@ -78,6 +90,8 @@
     # FQDN of the VSD or VSD cluster for this VSC
     #
     # vsd_fqdn: ""
+
+    ##### vCenter Parameters
 
     # < vCenter Datacenter Name >
     # Name of the vCenter Datacenter on which the VSC VM will be deployed. Defaults to the common vCenter Datacenter Name if not defined here.
@@ -93,6 +107,10 @@
     # Name of the vCenter Datastore on which the VSC VM will be deployed. Defaults to the common vCenter Datastore Name if not defined here.
     #
     # vcenter_datastore: (global vCenter Datastore Name)
+
+    ########################
+
+    ##### Health Parameters
 
     # < Expected number of BGP neighbors >
     # Used in postdeploy and health workflows as expected values if non-zero
@@ -119,6 +137,10 @@
     #
     # expected_num_gateway_ports: 0
 
+    #######################
+
+    ##### AWS Parameters
+
     # < Private Management IP >
     # Private Management IP Address of VSC Instances on AWS
     #
@@ -138,4 +160,6 @@
     # Control IP Address of VSC Instances on AWS
     #
     # internal_ctrl_ip: ""
+
+    ####################
 

--- a/examples/blank_deployment/vsds.yml
+++ b/examples/blank_deployment/vsds.yml
@@ -8,6 +8,8 @@
 # VSD 1
 #
 -
+    ##### Management Interface
+
     # < Hostname >
     # VSD Hostname
     #
@@ -28,6 +30,8 @@
     #
     mgmt_gateway: ""
 
+    ##########################
+
     # < VM name >
     # Name of the Virtual Machine on the Hypervisor
     #
@@ -37,6 +41,8 @@
     # Virtual Machine name of the new VSD. Used during Upgrade only
     #
     # upgrade_vmname: ""
+
+    ##### Target Server
 
     # < Target Server Type >
     # Type of hypervisor environment into which the instance will be created
@@ -49,10 +55,14 @@
     #
     target_server: ""
 
+    ###################
+
     # < Management Network Bridge >
     # Network Bridge used for the management interface of a component or the BOF interface on VSC. This will be a Distributed Virtual PortGroup (DVPG) when deploying on vCenter or a Linux network bridge when deploying on KVM. This field can be overridden by defining the management network bridge separately in the component configuration. Defaults to the global setting
     #
     # mgmt_bridge: (global Bridge interface)
+
+    ##### vCenter Parameters
 
     # < vCenter Datacenter Name >
     # Name of the vCenter Datacenter on which the VSD VM will be deployed. Defaults to the common vCenter Datacenter Name if not defined here.
@@ -68,6 +78,10 @@
     # Name of the vCenter Datastore on which the VSD VM will be deployed. Defaults to the common vCenter Datastore Name if not defined here.
     #
     # vcenter_datastore: (global vCenter Datastore Name)
+
+    ########################
+
+    ##### AWS Parameters
 
     # < AWS Region >
     # Only applicable for AWS deployments
@@ -98,4 +112,6 @@
     # ENI ID for VSD Instance on Management Subnet
     #
     # aws_mgmt_eni: ""
+
+    ####################
 

--- a/examples/blank_deployment/vstats.yml
+++ b/examples/blank_deployment/vstats.yml
@@ -8,6 +8,8 @@
 # VSTAT 1
 #
 -
+    ##### Management Interface
+
     # < Hostname >
     # Management network host name for the VSTAT
     #
@@ -28,6 +30,8 @@
     #
     mgmt_gateway: ""
 
+    ##########################
+
     # < VM name >
     # Name of the Virtual Machine on the Hypervisor
     #
@@ -37,6 +41,8 @@
     # Virtual Machine name of the new Stats VM. Used during Upgrade only
     #
     # upgrade_vmname: ""
+
+    ##### Target Server
 
     # < Target Server type >
     # Type of hypervisor environment into which the instance will be created
@@ -49,6 +55,8 @@
     #
     target_server: ""
 
+    ###################
+
     # < Management Network Bridge >
     # Network Bridge used for the management interface of a component or the BOF interface on VSC. This will be a Distributed Virtual PortGroup (DVPG) when deploying on vCenter or a Linux network bridge when deploying on KVM. This field can be overridden by defining the management network bridge separately in the component configuration. Defaults to the global setting
     #
@@ -58,6 +66,8 @@
     # FQDN of the VSD or VSD cluster for this VSTAT
     #
     # vsd_fqdn: 
+
+    ##### vCenter Parameters
 
     # < vCenter Datacenter Name >
     # Name of the vCenter Datacenter on which the VSTAT VM will be deployed. Defaults to the common vCenter Datacenter Name if not defined here.
@@ -69,10 +79,14 @@
     #
     # vcenter_cluster: (global vCenter Cluster Name)
 
+    ##### vCenter Parameters
+
     # < vCenter Datastore Name >
     # Name of the vCenter Datastore on which the VSTAT VM will be deployed. Defaults to the common vCenter Datastore Name if not defined here.
     #
     # vcenter_datastore: (global vCenter Datastore Name)
+
+    ##### AWS Parameters
 
     # < AWS AMI ID >
     # AMI ID for AWS instance
@@ -98,4 +112,6 @@
     # ENI ID for VSTAT Instance on Management Subnetwork
     #
     # aws_mgmt_eni: ""
+
+    ####################
 

--- a/examples/kvm_datacenter_install/common.yml
+++ b/examples/kvm_datacenter_install/common.yml
@@ -11,6 +11,8 @@
 #
 nuage_unzipped_files_dir: "/my/unzipped/filedir"
 
+##### Management Interface
+
 # < Domain Name >
 # Domain name for this deployment. E.g. company.net.
 #
@@ -20,6 +22,10 @@ dns_domain: "company.com"
 # For clustered VSD, the XMPP FQDN for the cluster; For standalone VSD, the FQDN of the single VSD
 #
 vsd_fqdn_global: "vsd1.company.com"
+
+##########################
+
+##### Network Bridges
 
 # < Management Network Bridge >
 # Network Bridge used for the management interface of a component or the BOF interface on VSC. This will be a Distributed Virtual PortGroup (DVPG) when deploying on vCenter or a Linux network bridge when deploying on KVM. This field can be overridden by defining the management network bridge separately in the component configuration
@@ -36,6 +42,10 @@ data_bridge: "192.168.110.2"
 #
 # access_bridge:
 
+#####################
+
+##### Network Services
+
 # < NTP Server IP(s) >
 # List of one or more NTP server IPv4 addresses that must be in dotted-decimal format
 #
@@ -46,6 +56,8 @@ ntp_server_list: [ "5.5.5.5", "2.2.2.2", ]
 #
 dns_server_list: [ "10.1.0.2", ]
 
+######################
+
 # < Timezone >
 # Timezone specification for the deployment
 #
@@ -55,6 +67,8 @@ dns_server_list: [ "10.1.0.2", ]
 # Full path to the directory on the KVM target server where qcow2 files will be copied
 #
 # images_path: /var/lib/libvirt/images/
+
+##### vCenter Parameters
 
 # < vCenter Datacenter >
 # vCenter datacenter to deploy Nuage components
@@ -81,6 +95,8 @@ dns_server_list: [ "10.1.0.2", ]
 #
 # vcenter_ovftool: /usr/bin/ovftool
 
+########################
+
 # < SSH Public Key >
 # Full path to the public key file to be injected into Nuage components to enable passwordless connectivity for configuration
 #
@@ -106,6 +122,8 @@ dns_server_list: [ "10.1.0.2", ]
 #
 # branding_zip_file:
 
+##### Yum
+
 # < Yum update >
 # Flag to indicate whether to perform a Yum update on VSD during the installation
 #
@@ -116,10 +134,14 @@ dns_server_list: [ "10.1.0.2", ]
 #
 # yum_proxy: NONE
 
+#########
+
 # < Nuage Software Version >
 # Nuage software version being installed. Optional for version comparison to skip deployment of some components that have already been installed.
 #
 # nuage_software_version:
+
+##### PoC Parameters
 
 # < VSD Disk Size >
 # Amount of VSD disk space to allocate, in GB. Valid only for KVM deployments. Note: Changing the default value is not a supported configuration.
@@ -146,6 +168,10 @@ dns_server_list: [ "10.1.0.2", ]
 #
 # vstat_ram: 16777216
 
+####################
+
+##### VSD Authentication
+
 # < VSD Architect URL >
 # VSD Architect URL. Required for tasks during Upgrade, Health Checks etc
 #
@@ -156,6 +182,10 @@ dns_server_list: [ "10.1.0.2", ]
 #
 # vsd_auth_enterprise: csp
 
+########################
+
+##### VCIN Authentication
+
 # < VCIN URL >
 # VCIN URL used for API interaction. Required for tasks like VRS-E upgrade (through VCIN)
 #
@@ -165,6 +195,10 @@ dns_server_list: [ "10.1.0.2", ]
 # Enterprise name used for authentication with VCIN. Required for tasks like VRS-E upgrade (through VCIN)
 #
 # vcin_auth_enterprise: csp
+
+#########################
+
+##### Libnetwork
 
 # < Libnetwork scope >
 # Scope of libnetworking support; local: connectivity between containers is limited to within the local host; global: connectivity between containers may span across hosts in the cluster
@@ -186,3 +220,5 @@ dns_server_list: [ "10.1.0.2", ]
 # Port portion of the URL pointing to the key-value store used for the Libnetwork cluster
 #
 # libnetwork_cluster_store_port: 8500
+
+################

--- a/examples/kvm_datacenter_install/vrss.yml
+++ b/examples/kvm_datacenter_install/vrss.yml
@@ -12,6 +12,8 @@
 # VRS 1
 #
 -
+    ##### Compute Nodes
+
     # < VRS Hypervisor OS type >
     # Hypervisor type for VRS installation
     # (u16.04, el7) 
@@ -23,6 +25,10 @@
     #
     vrs_ip_list: [ "192.168.110.50", "192.168.110.51", ]
 
+    ###################
+
+    ##### Controller Configuration
+
     # < Active Controller IP address >
     # Primary/Active Controller IP address
     #
@@ -32,6 +38,8 @@
     # Secondary/Standby Controller IP address
     #
     standby_controller_ip: "192.168.110.21"
+
+    ##############################
 
     # < DKMS install >
     # Optional DKMS module installation for MPLSoGRE tunnel type
@@ -48,6 +56,8 @@
 # VRS 2
 #
 -
+    ##### Compute Nodes
+
     # < VRS Hypervisor OS type >
     # Hypervisor type for VRS installation
     # (u16.04, el7) 
@@ -59,6 +69,10 @@
     #
     vrs_ip_list: [ "192.168.110.52", "192.168.110.53", ]
 
+    ###################
+
+    ##### Controller Configuration
+
     # < Active Controller IP address >
     # Primary/Active Controller IP address
     #
@@ -68,6 +82,8 @@
     # Secondary/Standby Controller IP address
     #
     standby_controller_ip: "192.168.110.21"
+
+    ##############################
 
     # < DKMS install >
     # Optional DKMS module installation for MPLSoGRE tunnel type
@@ -84,6 +100,8 @@
 # VRS 3
 #
 -
+    ##### Compute Nodes
+
     # < VRS Hypervisor OS type >
     # Hypervisor type for VRS installation
     # (u16.04, el7) 
@@ -95,6 +113,10 @@
     #
     vrs_ip_list: [ "192.168.110.54", ]
 
+    ###################
+
+    ##### Controller Configuration
+
     # < Active Controller IP address >
     # Primary/Active Controller IP address
     #
@@ -104,6 +126,8 @@
     # Secondary/Standby Controller IP address
     #
     standby_controller_ip: "192.168.110.21"
+
+    ##############################
 
     # < DKMS install >
     # Optional DKMS module installation for MPLSoGRE tunnel type

--- a/examples/kvm_datacenter_install/vscs.yml
+++ b/examples/kvm_datacenter_install/vscs.yml
@@ -12,6 +12,8 @@
 # VSC 1
 #
 -
+    ##### Management Network
+
     # < Hostname >
     # Hostname of the VSC instance
     #
@@ -32,6 +34,10 @@
     #
     mgmt_gateway: "192.168.110.1"
 
+    ########################
+
+    ##### Control Network
+
     # < Control IP address >
     # The Control/Data IP address of the controller
     #
@@ -41,6 +47,8 @@
     # Control network prefix length
     #
     ctrl_ip_prefix: 24
+
+    #####################
 
     # < System IP address >
     # Required for BGP pairing with peers
@@ -62,6 +70,8 @@
     #
     # mgmt_static_route_list: [ 0.0.0.0/1, 128.0.0.0/1 ]
 
+    ##### Target Server
+
     # < Target Server type >
     # Type of hypervisor environment into which the instance will be created
     # (kvm, vcenter, heat, aws) 
@@ -73,6 +83,8 @@
     #
     target_server: "10.105.1.100"
 
+    ###################
+
     # < Management Network Bridge >
     # Network Bridge used for the management interface of a component or the BOF interface on VSC. This will be a Distributed Virtual PortGroup (DVPG) when deploying on vCenter or a Linux network bridge when deploying on KVM. This field can be overridden by defining the management network bridge separately in the component configuration. Defaults to the global setting
     #
@@ -82,6 +94,8 @@
     # FQDN of the VSD or VSD cluster for this VSC
     #
     # vsd_fqdn: ""
+
+    ##### vCenter Parameters
 
     # < vCenter Datacenter Name >
     # Name of the vCenter Datacenter on which the VSC VM will be deployed. Defaults to the common vCenter Datacenter Name if not defined here.
@@ -97,6 +111,10 @@
     # Name of the vCenter Datastore on which the VSC VM will be deployed. Defaults to the common vCenter Datastore Name if not defined here.
     #
     # vcenter_datastore: (global vCenter Datastore Name)
+
+    ########################
+
+    ##### Health Parameters
 
     # < Expected number of BGP neighbors >
     # Used in postdeploy and health workflows as expected values if non-zero
@@ -123,6 +141,10 @@
     #
     # expected_num_gateway_ports: 0
 
+    #######################
+
+    ##### AWS Parameters
+
     # < Private Management IP >
     # Private Management IP Address of VSC Instances on AWS
     #
@@ -143,11 +165,15 @@
     #
     # internal_ctrl_ip: ""
 
+    ####################
+
 
 #
 # VSC 2
 #
 -
+    ##### Management Network
+
     # < Hostname >
     # Hostname of the VSC instance
     #
@@ -168,6 +194,10 @@
     #
     mgmt_gateway: "192.168.110.1"
 
+    ########################
+
+    ##### Control Network
+
     # < Control IP address >
     # The Control/Data IP address of the controller
     #
@@ -177,6 +207,8 @@
     # Control network prefix length
     #
     ctrl_ip_prefix: 24
+
+    #####################
 
     # < System IP address >
     # Required for BGP pairing with peers
@@ -198,6 +230,8 @@
     #
     # mgmt_static_route_list: [ 0.0.0.0/1, 128.0.0.0/1 ]
 
+    ##### Target Server
+
     # < Target Server type >
     # Type of hypervisor environment into which the instance will be created
     # (kvm, vcenter, heat, aws) 
@@ -209,6 +243,8 @@
     #
     target_server: "10.105.1.101"
 
+    ###################
+
     # < Management Network Bridge >
     # Network Bridge used for the management interface of a component or the BOF interface on VSC. This will be a Distributed Virtual PortGroup (DVPG) when deploying on vCenter or a Linux network bridge when deploying on KVM. This field can be overridden by defining the management network bridge separately in the component configuration. Defaults to the global setting
     #
@@ -218,6 +254,8 @@
     # FQDN of the VSD or VSD cluster for this VSC
     #
     # vsd_fqdn: ""
+
+    ##### vCenter Parameters
 
     # < vCenter Datacenter Name >
     # Name of the vCenter Datacenter on which the VSC VM will be deployed. Defaults to the common vCenter Datacenter Name if not defined here.
@@ -233,6 +271,10 @@
     # Name of the vCenter Datastore on which the VSC VM will be deployed. Defaults to the common vCenter Datastore Name if not defined here.
     #
     # vcenter_datastore: (global vCenter Datastore Name)
+
+    ########################
+
+    ##### Health Parameters
 
     # < Expected number of BGP neighbors >
     # Used in postdeploy and health workflows as expected values if non-zero
@@ -259,6 +301,10 @@
     #
     # expected_num_gateway_ports: 0
 
+    #######################
+
+    ##### AWS Parameters
+
     # < Private Management IP >
     # Private Management IP Address of VSC Instances on AWS
     #
@@ -278,6 +324,8 @@
     # Control IP Address of VSC Instances on AWS
     #
     # internal_ctrl_ip: ""
+
+    ####################
 
 
 

--- a/examples/kvm_datacenter_install/vsds.yml
+++ b/examples/kvm_datacenter_install/vsds.yml
@@ -12,6 +12,8 @@
 # VSD 1
 #
 -
+    ##### Management Interface
+
     # < Hostname >
     # VSD Hostname
     #
@@ -32,6 +34,8 @@
     #
     mgmt_gateway: "192.168.110.1"
 
+    ##########################
+
     # < VM name >
     # Name of the Virtual Machine on the Hypervisor
     #
@@ -41,6 +45,8 @@
     # Virtual Machine name of the new VSD. Used during Upgrade only
     #
     # upgrade_vmname: ""
+
+    ##### Target Server
 
     # < Target Server Type >
     # Type of hypervisor environment into which the instance will be created
@@ -53,10 +59,14 @@
     #
     target_server: "10.105.1.102"
 
+    ###################
+
     # < Management Network Bridge >
     # Network Bridge used for the management interface of a component or the BOF interface on VSC. This will be a Distributed Virtual PortGroup (DVPG) when deploying on vCenter or a Linux network bridge when deploying on KVM. This field can be overridden by defining the management network bridge separately in the component configuration. Defaults to the global setting
     #
     # mgmt_bridge: (global Bridge interface)
+
+    ##### vCenter Parameters
 
     # < vCenter Datacenter Name >
     # Name of the vCenter Datacenter on which the VSD VM will be deployed. Defaults to the common vCenter Datacenter Name if not defined here.
@@ -72,6 +82,10 @@
     # Name of the vCenter Datastore on which the VSD VM will be deployed. Defaults to the common vCenter Datastore Name if not defined here.
     #
     # vcenter_datastore: (global vCenter Datastore Name)
+
+    ########################
+
+    ##### AWS Parameters
 
     # < AWS Region >
     # Only applicable for AWS deployments
@@ -103,11 +117,15 @@
     #
     # aws_mgmt_eni: ""
 
+    ####################
+
 
 #
 # VSD 2
 #
 -
+    ##### Management Interface
+
     # < Hostname >
     # VSD Hostname
     #
@@ -128,6 +146,8 @@
     #
     mgmt_gateway: "192.168.110.1"
 
+    ##########################
+
     # < VM name >
     # Name of the Virtual Machine on the Hypervisor
     #
@@ -137,6 +157,8 @@
     # Virtual Machine name of the new VSD. Used during Upgrade only
     #
     # upgrade_vmname: ""
+
+    ##### Target Server
 
     # < Target Server Type >
     # Type of hypervisor environment into which the instance will be created
@@ -149,10 +171,14 @@
     #
     target_server: "10.105.1.103"
 
+    ###################
+
     # < Management Network Bridge >
     # Network Bridge used for the management interface of a component or the BOF interface on VSC. This will be a Distributed Virtual PortGroup (DVPG) when deploying on vCenter or a Linux network bridge when deploying on KVM. This field can be overridden by defining the management network bridge separately in the component configuration. Defaults to the global setting
     #
     # mgmt_bridge: (global Bridge interface)
+
+    ##### vCenter Parameters
 
     # < vCenter Datacenter Name >
     # Name of the vCenter Datacenter on which the VSD VM will be deployed. Defaults to the common vCenter Datacenter Name if not defined here.
@@ -168,6 +194,10 @@
     # Name of the vCenter Datastore on which the VSD VM will be deployed. Defaults to the common vCenter Datastore Name if not defined here.
     #
     # vcenter_datastore: (global vCenter Datastore Name)
+
+    ########################
+
+    ##### AWS Parameters
 
     # < AWS Region >
     # Only applicable for AWS deployments
@@ -199,11 +229,15 @@
     #
     # aws_mgmt_eni: ""
 
+    ####################
+
 
 #
 # VSD 3
 #
 -
+    ##### Management Interface
+
     # < Hostname >
     # VSD Hostname
     #
@@ -224,6 +258,8 @@
     #
     mgmt_gateway: "192.168.110.1"
 
+    ##########################
+
     # < VM name >
     # Name of the Virtual Machine on the Hypervisor
     #
@@ -233,6 +269,8 @@
     # Virtual Machine name of the new VSD. Used during Upgrade only
     #
     # upgrade_vmname: ""
+
+    ##### Target Server
 
     # < Target Server Type >
     # Type of hypervisor environment into which the instance will be created
@@ -245,10 +283,14 @@
     #
     target_server: "10.105.1.104"
 
+    ###################
+
     # < Management Network Bridge >
     # Network Bridge used for the management interface of a component or the BOF interface on VSC. This will be a Distributed Virtual PortGroup (DVPG) when deploying on vCenter or a Linux network bridge when deploying on KVM. This field can be overridden by defining the management network bridge separately in the component configuration. Defaults to the global setting
     #
     # mgmt_bridge: (global Bridge interface)
+
+    ##### vCenter Parameters
 
     # < vCenter Datacenter Name >
     # Name of the vCenter Datacenter on which the VSD VM will be deployed. Defaults to the common vCenter Datacenter Name if not defined here.
@@ -264,6 +306,10 @@
     # Name of the vCenter Datastore on which the VSD VM will be deployed. Defaults to the common vCenter Datastore Name if not defined here.
     #
     # vcenter_datastore: (global vCenter Datastore Name)
+
+    ########################
+
+    ##### AWS Parameters
 
     # < AWS Region >
     # Only applicable for AWS deployments
@@ -294,6 +340,8 @@
     # ENI ID for VSD Instance on Management Subnet
     #
     # aws_mgmt_eni: ""
+
+    ####################
 
 
 

--- a/examples/kvm_datacenter_install/vstats.yml
+++ b/examples/kvm_datacenter_install/vstats.yml
@@ -12,6 +12,8 @@
 # VSTAT 1
 #
 -
+    ##### Management Interface
+
     # < Hostname >
     # Management network host name for the VSTAT
     #
@@ -32,6 +34,8 @@
     #
     mgmt_gateway: "192.168.110.1"
 
+    ##########################
+
     # < VM name >
     # Name of the Virtual Machine on the Hypervisor
     #
@@ -41,6 +45,8 @@
     # Virtual Machine name of the new Stats VM. Used during Upgrade only
     #
     # upgrade_vmname: ""
+
+    ##### Target Server
 
     # < Target Server type >
     # Type of hypervisor environment into which the instance will be created
@@ -53,6 +59,8 @@
     #
     target_server: "10.105.1.105"
 
+    ###################
+
     # < Management Network Bridge >
     # Network Bridge used for the management interface of a component or the BOF interface on VSC. This will be a Distributed Virtual PortGroup (DVPG) when deploying on vCenter or a Linux network bridge when deploying on KVM. This field can be overridden by defining the management network bridge separately in the component configuration. Defaults to the global setting
     #
@@ -62,6 +70,8 @@
     # FQDN of the VSD or VSD cluster for this VSTAT
     #
     # vsd_fqdn:
+
+    ##### vCenter Parameters
 
     # < vCenter Datacenter Name >
     # Name of the vCenter Datacenter on which the VSTAT VM will be deployed. Defaults to the common vCenter Datacenter Name if not defined here.
@@ -73,10 +83,14 @@
     #
     # vcenter_cluster: (global vCenter Cluster Name)
 
+    ##### vCenter Parameters
+
     # < vCenter Datastore Name >
     # Name of the vCenter Datastore on which the VSTAT VM will be deployed. Defaults to the common vCenter Datastore Name if not defined here.
     #
     # vcenter_datastore: (global vCenter Datastore Name)
+
+    ##### AWS Parameters
 
     # < AWS AMI ID >
     # AMI ID for AWS instance
@@ -103,11 +117,15 @@
     #
     # aws_mgmt_eni: ""
 
+    ####################
+
 
 #
 # VSTAT 2
 #
 -
+    ##### Management Interface
+
     # < Hostname >
     # Management network host name for the VSTAT
     #
@@ -128,6 +146,8 @@
     #
     mgmt_gateway: "192.168.110.1"
 
+    ##########################
+
     # < VM name >
     # Name of the Virtual Machine on the Hypervisor
     #
@@ -137,6 +157,8 @@
     # Virtual Machine name of the new Stats VM. Used during Upgrade only
     #
     # upgrade_vmname: ""
+
+    ##### Target Server
 
     # < Target Server type >
     # Type of hypervisor environment into which the instance will be created
@@ -149,6 +171,8 @@
     #
     target_server: "10.105.1.106"
 
+    ###################
+
     # < Management Network Bridge >
     # Network Bridge used for the management interface of a component or the BOF interface on VSC. This will be a Distributed Virtual PortGroup (DVPG) when deploying on vCenter or a Linux network bridge when deploying on KVM. This field can be overridden by defining the management network bridge separately in the component configuration. Defaults to the global setting
     #
@@ -158,6 +182,8 @@
     # FQDN of the VSD or VSD cluster for this VSTAT
     #
     # vsd_fqdn:
+
+    ##### vCenter Parameters
 
     # < vCenter Datacenter Name >
     # Name of the vCenter Datacenter on which the VSTAT VM will be deployed. Defaults to the common vCenter Datacenter Name if not defined here.
@@ -169,10 +195,14 @@
     #
     # vcenter_cluster: (global vCenter Cluster Name)
 
+    ##### vCenter Parameters
+
     # < vCenter Datastore Name >
     # Name of the vCenter Datastore on which the VSTAT VM will be deployed. Defaults to the common vCenter Datastore Name if not defined here.
     #
     # vcenter_datastore: (global vCenter Datastore Name)
+
+    ##### AWS Parameters
 
     # < AWS AMI ID >
     # AMI ID for AWS instance
@@ -198,6 +228,8 @@
     # ENI ID for VSTAT Instance on Management Subnetwork
     #
     # aws_mgmt_eni: ""
+
+    ####################
 
 
 

--- a/examples/kvm_sdwan_install/common.yml
+++ b/examples/kvm_sdwan_install/common.yml
@@ -11,6 +11,8 @@
 #
 nuage_unzipped_files_dir: "/my/unzipped/filedir"
 
+##### Management Interface
+
 # < Domain Name >
 # Domain name for this deployment. E.g. company.net.
 #
@@ -20,6 +22,10 @@ dns_domain: "company.com"
 # For clustered VSD, the XMPP FQDN for the cluster; For standalone VSD, the FQDN of the single VSD
 #
 vsd_fqdn_global: "vsd1.company.com"
+
+##########################
+
+##### Network Bridges
 
 # < Management Network Bridge >
 # Network Bridge used for the management interface of a component or the BOF interface on VSC. This will be a Distributed Virtual PortGroup (DVPG) when deploying on vCenter or a Linux network bridge when deploying on KVM. This field can be overridden by defining the management network bridge separately in the component configuration
@@ -36,6 +42,10 @@ data_bridge: "192.168.110.2"
 #
 # access_bridge:
 
+#####################
+
+##### Network Services
+
 # < NTP Server IP(s) >
 # List of one or more NTP server IPv4 addresses that must be in dotted-decimal format
 #
@@ -46,6 +56,8 @@ ntp_server_list: [ "5.5.5.5", "2.2.2.2", ]
 #
 dns_server_list: [ "10.1.0.2", ]
 
+######################
+
 # < Timezone >
 # Timezone specification for the deployment
 #
@@ -55,6 +67,8 @@ dns_server_list: [ "10.1.0.2", ]
 # Full path to the directory on the KVM target server where qcow2 files will be copied
 #
 # images_path: /var/lib/libvirt/images/
+
+##### vCenter Parameters
 
 # < vCenter Datacenter >
 # vCenter datacenter to deploy Nuage components
@@ -81,6 +95,8 @@ dns_server_list: [ "10.1.0.2", ]
 #
 # vcenter_ovftool: /usr/bin/ovftool
 
+########################
+
 # < SSH Public Key >
 # Full path to the public key file to be injected into Nuage components to enable passwordless connectivity for configuration
 #
@@ -106,6 +122,8 @@ dns_server_list: [ "10.1.0.2", ]
 #
 # branding_zip_file:
 
+##### Yum
+
 # < Yum update >
 # Flag to indicate whether to perform a Yum update on VSD during the installation
 #
@@ -116,10 +134,14 @@ dns_server_list: [ "10.1.0.2", ]
 #
 # yum_proxy: NONE
 
+#########
+
 # < Nuage Software Version >
 # Nuage software version being installed. Optional for version comparison to skip deployment of some components that have already been installed.
 #
 # nuage_software_version:
+
+##### PoC Parameters
 
 # < VSD Disk Size >
 # Amount of VSD disk space to allocate, in GB. Valid only for KVM deployments. Note: Changing the default value is not a supported configuration.
@@ -146,6 +168,10 @@ dns_server_list: [ "10.1.0.2", ]
 #
 # vstat_ram: 16777216
 
+####################
+
+##### VSD Authentication
+
 # < VSD Architect URL >
 # VSD Architect URL. Required for tasks during Upgrade, Health Checks etc
 #
@@ -156,6 +182,10 @@ dns_server_list: [ "10.1.0.2", ]
 #
 # vsd_auth_enterprise: csp
 
+########################
+
+##### VCIN Authentication
+
 # < VCIN URL >
 # VCIN URL used for API interaction. Required for tasks like VRS-E upgrade (through VCIN)
 #
@@ -165,6 +195,10 @@ dns_server_list: [ "10.1.0.2", ]
 # Enterprise name used for authentication with VCIN. Required for tasks like VRS-E upgrade (through VCIN)
 #
 # vcin_auth_enterprise: csp
+
+#########################
+
+##### Libnetwork
 
 # < Libnetwork scope >
 # Scope of libnetworking support; local: connectivity between containers is limited to within the local host; global: connectivity between containers may span across hosts in the cluster
@@ -186,3 +220,5 @@ dns_server_list: [ "10.1.0.2", ]
 # Port portion of the URL pointing to the key-value store used for the Libnetwork cluster
 #
 # libnetwork_cluster_store_port: 8500
+
+################

--- a/examples/kvm_sdwan_install/vnsutils.yml
+++ b/examples/kvm_sdwan_install/vnsutils.yml
@@ -12,6 +12,8 @@
 # VNSUtil 1
 #
 -
+    ##### Management Interface
+
     # < Hostname >
     # Hostname of the Proxy/Util-VM instance
     #
@@ -32,10 +34,14 @@
     #
     mgmt_gateway: "192.168.110.1"
 
+    ##########################
+
     # < VM name >
     # Name of the Virtual Machine on the Hypervisor
     #
     # vmname: (Hostname)
+
+    ##### Target Server
 
     # < Target Server Type >
     # Type of hypervisor environment into which the instance will be created
@@ -48,10 +54,14 @@
     #
     target_server: "10.105.1.107"
 
+    ###################
+
     # < Management Bridge interface >
     # Network Bridge used for the management interface of a component or the BOF interface on the VM. This will be a Distributed Virtual PortGroup (DVPG) when deploying on vCenter or a Linux network bridge (ex: br0) when deploying on KVM. This field takes precedence over the value defined in the Commons section
     #
     # mgmt_bridge: (global Bridge interface)
+
+    ##### Data Interface
 
     # < VNSUTIL Data FQDN >
     #
@@ -70,6 +80,10 @@
     #
     # data_subnet:
 
+    ####################
+
+    ##### NSGv Parameters
+
     # < NSGV IP Address >
     #
     # nsgv_ip:
@@ -81,6 +95,10 @@
     # < NSGV Hostname >
     #
     # nsgv_hostname: nsgv1.(DNS Domain)
+
+    #####################
+
+    ##### vCenter Parameters
 
     # < vCenter Datacenter Name >
     # Name of the vCenter Datacenter on which the Proxy/Util VM will be deployed. Defaults to the common vCenter Datacenter Name if not defined here.
@@ -96,6 +114,10 @@
     # Name of the vCenter Datastore on which the Proxy/Util VM will be deployed. Defaults to the common vCenter Datastore Name if not defined here.
     #
     # vcenter_datastore: (global vCenter Datastore Name)
+
+    ########################
+
+    ##### AWS Parameters
 
     # < AWS Region >
     # Only applicable for AWS deployments
@@ -126,6 +148,8 @@
     # ENI ID for VNSUTIL on Data Interface
     #
     # aws_data_eni: ""
+
+    ####################
 
 
 

--- a/examples/kvm_sdwan_install/vscs.yml
+++ b/examples/kvm_sdwan_install/vscs.yml
@@ -12,6 +12,8 @@
 # VSC 1
 #
 -
+    ##### Management Network
+
     # < Hostname >
     # Hostname of the VSC instance
     #
@@ -32,6 +34,10 @@
     #
     mgmt_gateway: "192.168.110.1"
 
+    ########################
+
+    ##### Control Network
+
     # < Control IP address >
     # The Control/Data IP address of the controller
     #
@@ -41,6 +47,8 @@
     # Control network prefix length
     #
     ctrl_ip_prefix: 24
+
+    #####################
 
     # < System IP address >
     # Required for BGP pairing with peers
@@ -62,6 +70,8 @@
     #
     # mgmt_static_route_list: [ 0.0.0.0/1, 128.0.0.0/1 ]
 
+    ##### Target Server
+
     # < Target Server type >
     # Type of hypervisor environment into which the instance will be created
     # (kvm, vcenter, heat, aws) 
@@ -73,6 +83,8 @@
     #
     target_server: "10.105.1.100"
 
+    ###################
+
     # < Management Network Bridge >
     # Network Bridge used for the management interface of a component or the BOF interface on VSC. This will be a Distributed Virtual PortGroup (DVPG) when deploying on vCenter or a Linux network bridge when deploying on KVM. This field can be overridden by defining the management network bridge separately in the component configuration. Defaults to the global setting
     #
@@ -82,6 +94,8 @@
     # FQDN of the VSD or VSD cluster for this VSC
     #
     # vsd_fqdn: ""
+
+    ##### vCenter Parameters
 
     # < vCenter Datacenter Name >
     # Name of the vCenter Datacenter on which the VSC VM will be deployed. Defaults to the common vCenter Datacenter Name if not defined here.
@@ -97,6 +111,10 @@
     # Name of the vCenter Datastore on which the VSC VM will be deployed. Defaults to the common vCenter Datastore Name if not defined here.
     #
     # vcenter_datastore: (global vCenter Datastore Name)
+
+    ########################
+
+    ##### Health Parameters
 
     # < Expected number of BGP neighbors >
     # Used in postdeploy and health workflows as expected values if non-zero
@@ -123,6 +141,10 @@
     #
     # expected_num_gateway_ports: 0
 
+    #######################
+
+    ##### AWS Parameters
+
     # < Private Management IP >
     # Private Management IP Address of VSC Instances on AWS
     #
@@ -143,11 +165,15 @@
     #
     # internal_ctrl_ip: ""
 
+    ####################
+
 
 #
 # VSC 2
 #
 -
+    ##### Management Network
+
     # < Hostname >
     # Hostname of the VSC instance
     #
@@ -168,6 +194,10 @@
     #
     mgmt_gateway: "192.168.110.1"
 
+    ########################
+
+    ##### Control Network
+
     # < Control IP address >
     # The Control/Data IP address of the controller
     #
@@ -177,6 +207,8 @@
     # Control network prefix length
     #
     ctrl_ip_prefix: 24
+
+    #####################
 
     # < System IP address >
     # Required for BGP pairing with peers
@@ -198,6 +230,8 @@
     #
     # mgmt_static_route_list: [ 0.0.0.0/1, 128.0.0.0/1 ]
 
+    ##### Target Server
+
     # < Target Server type >
     # Type of hypervisor environment into which the instance will be created
     # (kvm, vcenter, heat, aws) 
@@ -209,6 +243,8 @@
     #
     target_server: "10.105.1.101"
 
+    ###################
+
     # < Management Network Bridge >
     # Network Bridge used for the management interface of a component or the BOF interface on VSC. This will be a Distributed Virtual PortGroup (DVPG) when deploying on vCenter or a Linux network bridge when deploying on KVM. This field can be overridden by defining the management network bridge separately in the component configuration. Defaults to the global setting
     #
@@ -218,6 +254,8 @@
     # FQDN of the VSD or VSD cluster for this VSC
     #
     # vsd_fqdn: ""
+
+    ##### vCenter Parameters
 
     # < vCenter Datacenter Name >
     # Name of the vCenter Datacenter on which the VSC VM will be deployed. Defaults to the common vCenter Datacenter Name if not defined here.
@@ -233,6 +271,10 @@
     # Name of the vCenter Datastore on which the VSC VM will be deployed. Defaults to the common vCenter Datastore Name if not defined here.
     #
     # vcenter_datastore: (global vCenter Datastore Name)
+
+    ########################
+
+    ##### Health Parameters
 
     # < Expected number of BGP neighbors >
     # Used in postdeploy and health workflows as expected values if non-zero
@@ -259,6 +301,10 @@
     #
     # expected_num_gateway_ports: 0
 
+    #######################
+
+    ##### AWS Parameters
+
     # < Private Management IP >
     # Private Management IP Address of VSC Instances on AWS
     #
@@ -278,6 +324,8 @@
     # Control IP Address of VSC Instances on AWS
     #
     # internal_ctrl_ip: ""
+
+    ####################
 
 
 

--- a/examples/kvm_sdwan_install/vsds.yml
+++ b/examples/kvm_sdwan_install/vsds.yml
@@ -12,6 +12,8 @@
 # VSD 1
 #
 -
+    ##### Management Interface
+
     # < Hostname >
     # VSD Hostname
     #
@@ -32,6 +34,8 @@
     #
     mgmt_gateway: "192.168.110.1"
 
+    ##########################
+
     # < VM name >
     # Name of the Virtual Machine on the Hypervisor
     #
@@ -41,6 +45,8 @@
     # Virtual Machine name of the new VSD. Used during Upgrade only
     #
     # upgrade_vmname: ""
+
+    ##### Target Server
 
     # < Target Server Type >
     # Type of hypervisor environment into which the instance will be created
@@ -53,10 +59,14 @@
     #
     target_server: "10.105.1.102"
 
+    ###################
+
     # < Management Network Bridge >
     # Network Bridge used for the management interface of a component or the BOF interface on VSC. This will be a Distributed Virtual PortGroup (DVPG) when deploying on vCenter or a Linux network bridge when deploying on KVM. This field can be overridden by defining the management network bridge separately in the component configuration. Defaults to the global setting
     #
     # mgmt_bridge: (global Bridge interface)
+
+    ##### vCenter Parameters
 
     # < vCenter Datacenter Name >
     # Name of the vCenter Datacenter on which the VSD VM will be deployed. Defaults to the common vCenter Datacenter Name if not defined here.
@@ -72,6 +82,10 @@
     # Name of the vCenter Datastore on which the VSD VM will be deployed. Defaults to the common vCenter Datastore Name if not defined here.
     #
     # vcenter_datastore: (global vCenter Datastore Name)
+
+    ########################
+
+    ##### AWS Parameters
 
     # < AWS Region >
     # Only applicable for AWS deployments
@@ -103,11 +117,15 @@
     #
     # aws_mgmt_eni: ""
 
+    ####################
+
 
 #
 # VSD 2
 #
 -
+    ##### Management Interface
+
     # < Hostname >
     # VSD Hostname
     #
@@ -128,6 +146,8 @@
     #
     mgmt_gateway: "192.168.110.1"
 
+    ##########################
+
     # < VM name >
     # Name of the Virtual Machine on the Hypervisor
     #
@@ -137,6 +157,8 @@
     # Virtual Machine name of the new VSD. Used during Upgrade only
     #
     # upgrade_vmname: ""
+
+    ##### Target Server
 
     # < Target Server Type >
     # Type of hypervisor environment into which the instance will be created
@@ -149,10 +171,14 @@
     #
     target_server: "10.105.1.103"
 
+    ###################
+
     # < Management Network Bridge >
     # Network Bridge used for the management interface of a component or the BOF interface on VSC. This will be a Distributed Virtual PortGroup (DVPG) when deploying on vCenter or a Linux network bridge when deploying on KVM. This field can be overridden by defining the management network bridge separately in the component configuration. Defaults to the global setting
     #
     # mgmt_bridge: (global Bridge interface)
+
+    ##### vCenter Parameters
 
     # < vCenter Datacenter Name >
     # Name of the vCenter Datacenter on which the VSD VM will be deployed. Defaults to the common vCenter Datacenter Name if not defined here.
@@ -168,6 +194,10 @@
     # Name of the vCenter Datastore on which the VSD VM will be deployed. Defaults to the common vCenter Datastore Name if not defined here.
     #
     # vcenter_datastore: (global vCenter Datastore Name)
+
+    ########################
+
+    ##### AWS Parameters
 
     # < AWS Region >
     # Only applicable for AWS deployments
@@ -199,11 +229,15 @@
     #
     # aws_mgmt_eni: ""
 
+    ####################
+
 
 #
 # VSD 3
 #
 -
+    ##### Management Interface
+
     # < Hostname >
     # VSD Hostname
     #
@@ -224,6 +258,8 @@
     #
     mgmt_gateway: "192.168.110.1"
 
+    ##########################
+
     # < VM name >
     # Name of the Virtual Machine on the Hypervisor
     #
@@ -233,6 +269,8 @@
     # Virtual Machine name of the new VSD. Used during Upgrade only
     #
     # upgrade_vmname: ""
+
+    ##### Target Server
 
     # < Target Server Type >
     # Type of hypervisor environment into which the instance will be created
@@ -245,10 +283,14 @@
     #
     target_server: "10.105.1.104"
 
+    ###################
+
     # < Management Network Bridge >
     # Network Bridge used for the management interface of a component or the BOF interface on VSC. This will be a Distributed Virtual PortGroup (DVPG) when deploying on vCenter or a Linux network bridge when deploying on KVM. This field can be overridden by defining the management network bridge separately in the component configuration. Defaults to the global setting
     #
     # mgmt_bridge: (global Bridge interface)
+
+    ##### vCenter Parameters
 
     # < vCenter Datacenter Name >
     # Name of the vCenter Datacenter on which the VSD VM will be deployed. Defaults to the common vCenter Datacenter Name if not defined here.
@@ -264,6 +306,10 @@
     # Name of the vCenter Datastore on which the VSD VM will be deployed. Defaults to the common vCenter Datastore Name if not defined here.
     #
     # vcenter_datastore: (global vCenter Datastore Name)
+
+    ########################
+
+    ##### AWS Parameters
 
     # < AWS Region >
     # Only applicable for AWS deployments
@@ -294,6 +340,8 @@
     # ENI ID for VSD Instance on Management Subnet
     #
     # aws_mgmt_eni: ""
+
+    ####################
 
 
 

--- a/examples/kvm_sdwan_install/vstats.yml
+++ b/examples/kvm_sdwan_install/vstats.yml
@@ -12,6 +12,8 @@
 # VSTAT 1
 #
 -
+    ##### Management Interface
+
     # < Hostname >
     # Management network host name for the VSTAT
     #
@@ -32,6 +34,8 @@
     #
     mgmt_gateway: "192.168.110.1"
 
+    ##########################
+
     # < VM name >
     # Name of the Virtual Machine on the Hypervisor
     #
@@ -41,6 +45,8 @@
     # Virtual Machine name of the new Stats VM. Used during Upgrade only
     #
     # upgrade_vmname: ""
+
+    ##### Target Server
 
     # < Target Server type >
     # Type of hypervisor environment into which the instance will be created
@@ -53,6 +59,8 @@
     #
     target_server: "10.105.1.105"
 
+    ###################
+
     # < Management Network Bridge >
     # Network Bridge used for the management interface of a component or the BOF interface on VSC. This will be a Distributed Virtual PortGroup (DVPG) when deploying on vCenter or a Linux network bridge when deploying on KVM. This field can be overridden by defining the management network bridge separately in the component configuration. Defaults to the global setting
     #
@@ -62,6 +70,8 @@
     # FQDN of the VSD or VSD cluster for this VSTAT
     #
     # vsd_fqdn:
+
+    ##### vCenter Parameters
 
     # < vCenter Datacenter Name >
     # Name of the vCenter Datacenter on which the VSTAT VM will be deployed. Defaults to the common vCenter Datacenter Name if not defined here.
@@ -73,10 +83,14 @@
     #
     # vcenter_cluster: (global vCenter Cluster Name)
 
+    ##### vCenter Parameters
+
     # < vCenter Datastore Name >
     # Name of the vCenter Datastore on which the VSTAT VM will be deployed. Defaults to the common vCenter Datastore Name if not defined here.
     #
     # vcenter_datastore: (global vCenter Datastore Name)
+
+    ##### AWS Parameters
 
     # < AWS AMI ID >
     # AMI ID for AWS instance
@@ -103,11 +117,15 @@
     #
     # aws_mgmt_eni: ""
 
+    ####################
+
 
 #
 # VSTAT 2
 #
 -
+    ##### Management Interface
+
     # < Hostname >
     # Management network host name for the VSTAT
     #
@@ -128,6 +146,8 @@
     #
     mgmt_gateway: "192.168.110.1"
 
+    ##########################
+
     # < VM name >
     # Name of the Virtual Machine on the Hypervisor
     #
@@ -137,6 +157,8 @@
     # Virtual Machine name of the new Stats VM. Used during Upgrade only
     #
     # upgrade_vmname: ""
+
+    ##### Target Server
 
     # < Target Server type >
     # Type of hypervisor environment into which the instance will be created
@@ -149,6 +171,8 @@
     #
     target_server: "10.105.1.106"
 
+    ###################
+
     # < Management Network Bridge >
     # Network Bridge used for the management interface of a component or the BOF interface on VSC. This will be a Distributed Virtual PortGroup (DVPG) when deploying on vCenter or a Linux network bridge when deploying on KVM. This field can be overridden by defining the management network bridge separately in the component configuration. Defaults to the global setting
     #
@@ -158,6 +182,8 @@
     # FQDN of the VSD or VSD cluster for this VSTAT
     #
     # vsd_fqdn:
+
+    ##### vCenter Parameters
 
     # < vCenter Datacenter Name >
     # Name of the vCenter Datacenter on which the VSTAT VM will be deployed. Defaults to the common vCenter Datacenter Name if not defined here.
@@ -169,10 +195,14 @@
     #
     # vcenter_cluster: (global vCenter Cluster Name)
 
+    ##### vCenter Parameters
+
     # < vCenter Datastore Name >
     # Name of the vCenter Datastore on which the VSTAT VM will be deployed. Defaults to the common vCenter Datastore Name if not defined here.
     #
     # vcenter_datastore: (global vCenter Datastore Name)
+
+    ##### AWS Parameters
 
     # < AWS AMI ID >
     # AMI ID for AWS instance
@@ -198,6 +228,8 @@
     # ENI ID for VSTAT Instance on Management Subnetwork
     #
     # aws_mgmt_eni: ""
+
+    ####################
 
 
 

--- a/examples/kvm_vsc_upgrade/common.yml
+++ b/examples/kvm_vsc_upgrade/common.yml
@@ -11,6 +11,8 @@
 #
 nuage_unzipped_files_dir: "/my/unzipped/filedir"
 
+##### Management Interface
+
 # < Domain Name >
 # Domain name for this deployment. E.g. company.net.
 #
@@ -20,6 +22,10 @@ dns_domain: "company.com"
 # For clustered VSD, the XMPP FQDN for the cluster; For standalone VSD, the FQDN of the single VSD
 #
 vsd_fqdn_global: "vsd1.company.com"
+
+##########################
+
+##### Network Bridges
 
 # < Management Network Bridge >
 # Network Bridge used for the management interface of a component or the BOF interface on VSC. This will be a Distributed Virtual PortGroup (DVPG) when deploying on vCenter or a Linux network bridge when deploying on KVM. This field can be overridden by defining the management network bridge separately in the component configuration
@@ -36,6 +42,10 @@ data_bridge: "192.168.110.2"
 #
 # access_bridge:
 
+#####################
+
+##### Network Services
+
 # < NTP Server IP(s) >
 # List of one or more NTP server IPv4 addresses that must be in dotted-decimal format
 #
@@ -46,6 +56,8 @@ ntp_server_list: [ "5.5.5.5", "2.2.2.2", ]
 #
 dns_server_list: [ "10.1.0.2", ]
 
+######################
+
 # < Timezone >
 # Timezone specification for the deployment
 #
@@ -55,6 +67,8 @@ dns_server_list: [ "10.1.0.2", ]
 # Full path to the directory on the KVM target server where qcow2 files will be copied
 #
 # images_path: /var/lib/libvirt/images/
+
+##### vCenter Parameters
 
 # < vCenter Datacenter >
 # vCenter datacenter to deploy Nuage components
@@ -81,6 +95,8 @@ dns_server_list: [ "10.1.0.2", ]
 #
 # vcenter_ovftool: /usr/bin/ovftool
 
+########################
+
 # < SSH Public Key >
 # Full path to the public key file to be injected into Nuage components to enable passwordless connectivity for configuration
 #
@@ -106,6 +122,8 @@ dns_server_list: [ "10.1.0.2", ]
 #
 # branding_zip_file:
 
+##### Yum
+
 # < Yum update >
 # Flag to indicate whether to perform a Yum update on VSD during the installation
 #
@@ -116,10 +134,14 @@ dns_server_list: [ "10.1.0.2", ]
 #
 # yum_proxy: NONE
 
+#########
+
 # < Nuage Software Version >
 # Nuage software version being installed. Optional for version comparison to skip deployment of some components that have already been installed.
 #
 # nuage_software_version:
+
+##### PoC Parameters
 
 # < VSD Disk Size >
 # Amount of VSD disk space to allocate, in GB. Valid only for KVM deployments. Note: Changing the default value is not a supported configuration.
@@ -146,6 +168,10 @@ dns_server_list: [ "10.1.0.2", ]
 #
 # vstat_ram: 16777216
 
+####################
+
+##### VSD Authentication
+
 # < VSD Architect URL >
 # VSD Architect URL. Required for tasks during Upgrade, Health Checks etc
 #
@@ -156,6 +182,10 @@ dns_server_list: [ "10.1.0.2", ]
 #
 # vsd_auth_enterprise: csp
 
+########################
+
+##### VCIN Authentication
+
 # < VCIN URL >
 # VCIN URL used for API interaction. Required for tasks like VRS-E upgrade (through VCIN)
 #
@@ -165,6 +195,10 @@ dns_server_list: [ "10.1.0.2", ]
 # Enterprise name used for authentication with VCIN. Required for tasks like VRS-E upgrade (through VCIN)
 #
 # vcin_auth_enterprise: csp
+
+#########################
+
+##### Libnetwork
 
 # < Libnetwork scope >
 # Scope of libnetworking support; local: connectivity between containers is limited to within the local host; global: connectivity between containers may span across hosts in the cluster
@@ -186,3 +220,5 @@ dns_server_list: [ "10.1.0.2", ]
 # Port portion of the URL pointing to the key-value store used for the Libnetwork cluster
 #
 # libnetwork_cluster_store_port: 8500
+
+################

--- a/examples/kvm_vsc_upgrade/credentials.yml
+++ b/examples/kvm_vsc_upgrade/credentials.yml
@@ -61,6 +61,8 @@ vsc_custom_password: "vscpass"
 #
 # vstat_custom_password:
 
+##### Custom VSD Passwords
+
 # < VSD cna Password >
 # Custom VSD cna password
 #
@@ -111,6 +113,10 @@ vsc_custom_password: "vscpass"
 #
 # vsd_keyserverstore_password:
 
+##########################
+
+##### AWS Credentials
+
 # < AWS Access key >
 # Access key for AWS
 #
@@ -120,3 +126,5 @@ vsc_custom_password: "vscpass"
 # Secret key for AWS
 #
 # aws_secret_key:
+
+#####################

--- a/examples/kvm_vsc_upgrade/vscs.yml
+++ b/examples/kvm_vsc_upgrade/vscs.yml
@@ -12,6 +12,8 @@
 # VSC 1
 #
 -
+    ##### Management Network
+
     # < Hostname >
     # Hostname of the VSC instance
     #
@@ -32,6 +34,10 @@
     #
     mgmt_gateway: "192.168.110.1"
 
+    ########################
+
+    ##### Control Network
+
     # < Control IP address >
     # The Control/Data IP address of the controller
     #
@@ -41,6 +47,8 @@
     # Control network prefix length
     #
     ctrl_ip_prefix: 24
+
+    #####################
 
     # < System IP address >
     # Required for BGP pairing with peers
@@ -62,6 +70,8 @@
     #
     # mgmt_static_route_list: [ 0.0.0.0/1, 128.0.0.0/1 ]
 
+    ##### Target Server
+
     # < Target Server type >
     # Type of hypervisor environment into which the instance will be created
     # (kvm, vcenter, heat, aws) 
@@ -73,6 +83,8 @@
     #
     target_server: "10.105.1.100"
 
+    ###################
+
     # < Management Network Bridge >
     # Network Bridge used for the management interface of a component or the BOF interface on VSC. This will be a Distributed Virtual PortGroup (DVPG) when deploying on vCenter or a Linux network bridge when deploying on KVM. This field can be overridden by defining the management network bridge separately in the component configuration. Defaults to the global setting
     #
@@ -82,6 +94,8 @@
     # FQDN of the VSD or VSD cluster for this VSC
     #
     # vsd_fqdn: ""
+
+    ##### vCenter Parameters
 
     # < vCenter Datacenter Name >
     # Name of the vCenter Datacenter on which the VSC VM will be deployed. Defaults to the common vCenter Datacenter Name if not defined here.
@@ -97,6 +111,10 @@
     # Name of the vCenter Datastore on which the VSC VM will be deployed. Defaults to the common vCenter Datastore Name if not defined here.
     #
     vcenter_datastore: "datastoreA"
+
+    ########################
+
+    ##### Health Parameters
 
     # < Expected number of BGP neighbors >
     # Used in postdeploy and health workflows as expected values if non-zero
@@ -123,6 +141,10 @@
     #
     # expected_num_gateway_ports: 0
 
+    #######################
+
+    ##### AWS Parameters
+
     # < Private Management IP >
     # Private Management IP Address of VSC Instances on AWS
     #
@@ -143,11 +165,15 @@
     #
     # internal_ctrl_ip: ""
 
+    ####################
+
 
 #
 # VSC 2
 #
 -
+    ##### Management Network
+
     # < Hostname >
     # Hostname of the VSC instance
     #
@@ -168,6 +194,10 @@
     #
     mgmt_gateway: "192.168.110.1"
 
+    ########################
+
+    ##### Control Network
+
     # < Control IP address >
     # The Control/Data IP address of the controller
     #
@@ -177,6 +207,8 @@
     # Control network prefix length
     #
     ctrl_ip_prefix: 24
+
+    #####################
 
     # < System IP address >
     # Required for BGP pairing with peers
@@ -198,6 +230,8 @@
     #
     # mgmt_static_route_list: [ 0.0.0.0/1, 128.0.0.0/1 ]
 
+    ##### Target Server
+
     # < Target Server type >
     # Type of hypervisor environment into which the instance will be created
     # (kvm, vcenter, heat, aws) 
@@ -209,6 +243,8 @@
     #
     target_server: "10.105.1.101"
 
+    ###################
+
     # < Management Network Bridge >
     # Network Bridge used for the management interface of a component or the BOF interface on VSC. This will be a Distributed Virtual PortGroup (DVPG) when deploying on vCenter or a Linux network bridge when deploying on KVM. This field can be overridden by defining the management network bridge separately in the component configuration. Defaults to the global setting
     #
@@ -218,6 +254,8 @@
     # FQDN of the VSD or VSD cluster for this VSC
     #
     # vsd_fqdn: ""
+
+    ##### vCenter Parameters
 
     # < vCenter Datacenter Name >
     # Name of the vCenter Datacenter on which the VSC VM will be deployed. Defaults to the common vCenter Datacenter Name if not defined here.
@@ -233,6 +271,10 @@
     # Name of the vCenter Datastore on which the VSC VM will be deployed. Defaults to the common vCenter Datastore Name if not defined here.
     #
     vcenter_datastore: "datastoreB"
+
+    ########################
+
+    ##### Health Parameters
 
     # < Expected number of BGP neighbors >
     # Used in postdeploy and health workflows as expected values if non-zero
@@ -259,6 +301,10 @@
     #
     # expected_num_gateway_ports: 0
 
+    #######################
+
+    ##### AWS Parameters
+
     # < Private Management IP >
     # Private Management IP Address of VSC Instances on AWS
     #
@@ -278,6 +324,8 @@
     # Control IP Address of VSC Instances on AWS
     #
     # internal_ctrl_ip: ""
+
+    ####################
 
 
 

--- a/examples/kvm_vsc_upgrade/vsds.yml
+++ b/examples/kvm_vsc_upgrade/vsds.yml
@@ -12,6 +12,8 @@
 # VSD 1
 #
 -
+    ##### Management Interface
+
     # < Hostname >
     # VSD Hostname
     #
@@ -32,6 +34,8 @@
     #
     mgmt_gateway: "192.168.110.1"
 
+    ##########################
+
     # < VM name >
     # Name of the Virtual Machine on the Hypervisor
     #
@@ -41,6 +45,8 @@
     # Virtual Machine name of the new VSD. Used during Upgrade only
     #
     # upgrade_vmname: ""
+
+    ##### Target Server
 
     # < Target Server Type >
     # Type of hypervisor environment into which the instance will be created
@@ -53,10 +59,14 @@
     #
     target_server: "10.105.1.102"
 
+    ###################
+
     # < Management Network Bridge >
     # Network Bridge used for the management interface of a component or the BOF interface on VSC. This will be a Distributed Virtual PortGroup (DVPG) when deploying on vCenter or a Linux network bridge when deploying on KVM. This field can be overridden by defining the management network bridge separately in the component configuration. Defaults to the global setting
     #
     # mgmt_bridge: (global Bridge interface)
+
+    ##### vCenter Parameters
 
     # < vCenter Datacenter Name >
     # Name of the vCenter Datacenter on which the VSD VM will be deployed. Defaults to the common vCenter Datacenter Name if not defined here.
@@ -72,6 +82,10 @@
     # Name of the vCenter Datastore on which the VSD VM will be deployed. Defaults to the common vCenter Datastore Name if not defined here.
     #
     vcenter_datastore: "datastoreA"
+
+    ########################
+
+    ##### AWS Parameters
 
     # < AWS Region >
     # Only applicable for AWS deployments
@@ -103,11 +117,15 @@
     #
     # aws_mgmt_eni: ""
 
+    ####################
+
 
 #
 # VSD 2
 #
 -
+    ##### Management Interface
+
     # < Hostname >
     # VSD Hostname
     #
@@ -128,6 +146,8 @@
     #
     mgmt_gateway: "192.168.110.1"
 
+    ##########################
+
     # < VM name >
     # Name of the Virtual Machine on the Hypervisor
     #
@@ -137,6 +157,8 @@
     # Virtual Machine name of the new VSD. Used during Upgrade only
     #
     # upgrade_vmname: ""
+
+    ##### Target Server
 
     # < Target Server Type >
     # Type of hypervisor environment into which the instance will be created
@@ -149,10 +171,14 @@
     #
     target_server: "10.105.1.103"
 
+    ###################
+
     # < Management Network Bridge >
     # Network Bridge used for the management interface of a component or the BOF interface on VSC. This will be a Distributed Virtual PortGroup (DVPG) when deploying on vCenter or a Linux network bridge when deploying on KVM. This field can be overridden by defining the management network bridge separately in the component configuration. Defaults to the global setting
     #
     # mgmt_bridge: (global Bridge interface)
+
+    ##### vCenter Parameters
 
     # < vCenter Datacenter Name >
     # Name of the vCenter Datacenter on which the VSD VM will be deployed. Defaults to the common vCenter Datacenter Name if not defined here.
@@ -168,6 +194,10 @@
     # Name of the vCenter Datastore on which the VSD VM will be deployed. Defaults to the common vCenter Datastore Name if not defined here.
     #
     vcenter_datastore: "datastoreA"
+
+    ########################
+
+    ##### AWS Parameters
 
     # < AWS Region >
     # Only applicable for AWS deployments
@@ -199,11 +229,15 @@
     #
     # aws_mgmt_eni: ""
 
+    ####################
+
 
 #
 # VSD 3
 #
 -
+    ##### Management Interface
+
     # < Hostname >
     # VSD Hostname
     #
@@ -224,6 +258,8 @@
     #
     mgmt_gateway: "192.168.110.1"
 
+    ##########################
+
     # < VM name >
     # Name of the Virtual Machine on the Hypervisor
     #
@@ -233,6 +269,8 @@
     # Virtual Machine name of the new VSD. Used during Upgrade only
     #
     # upgrade_vmname: ""
+
+    ##### Target Server
 
     # < Target Server Type >
     # Type of hypervisor environment into which the instance will be created
@@ -245,10 +283,14 @@
     #
     target_server: "10.105.1.104"
 
+    ###################
+
     # < Management Network Bridge >
     # Network Bridge used for the management interface of a component or the BOF interface on VSC. This will be a Distributed Virtual PortGroup (DVPG) when deploying on vCenter or a Linux network bridge when deploying on KVM. This field can be overridden by defining the management network bridge separately in the component configuration. Defaults to the global setting
     #
     # mgmt_bridge: (global Bridge interface)
+
+    ##### vCenter Parameters
 
     # < vCenter Datacenter Name >
     # Name of the vCenter Datacenter on which the VSD VM will be deployed. Defaults to the common vCenter Datacenter Name if not defined here.
@@ -264,6 +306,10 @@
     # Name of the vCenter Datastore on which the VSD VM will be deployed. Defaults to the common vCenter Datastore Name if not defined here.
     #
     vcenter_datastore: "datastoreB"
+
+    ########################
+
+    ##### AWS Parameters
 
     # < AWS Region >
     # Only applicable for AWS deployments
@@ -294,6 +340,8 @@
     # ENI ID for VSD Instance on Management Subnet
     #
     # aws_mgmt_eni: ""
+
+    ####################
 
 
 

--- a/examples/kvm_vsd_install/common.yml
+++ b/examples/kvm_vsd_install/common.yml
@@ -11,6 +11,8 @@
 #
 nuage_unzipped_files_dir: "/my/unzipped/filedir"
 
+##### Management Interface
+
 # < Domain Name >
 # Domain name for this deployment. E.g. company.net.
 #
@@ -20,6 +22,10 @@ dns_domain: "company.com"
 # For clustered VSD, the XMPP FQDN for the cluster; For standalone VSD, the FQDN of the single VSD
 #
 vsd_fqdn_global: "vsd.company.com"
+
+##########################
+
+##### Network Bridges
 
 # < Management Network Bridge >
 # Network Bridge used for the management interface of a component or the BOF interface on VSC. This will be a Distributed Virtual PortGroup (DVPG) when deploying on vCenter or a Linux network bridge when deploying on KVM. This field can be overridden by defining the management network bridge separately in the component configuration
@@ -36,6 +42,10 @@ data_bridge: "192.168.110.2"
 #
 # access_bridge:
 
+#####################
+
+##### Network Services
+
 # < NTP Server IP(s) >
 # List of one or more NTP server IPv4 addresses that must be in dotted-decimal format
 #
@@ -46,6 +56,8 @@ ntp_server_list: [ "5.5.5.5", "2.2.2.2", ]
 #
 dns_server_list: [ "10.1.0.2", ]
 
+######################
+
 # < Timezone >
 # Timezone specification for the deployment
 #
@@ -55,6 +67,8 @@ dns_server_list: [ "10.1.0.2", ]
 # Full path to the directory on the KVM target server where qcow2 files will be copied
 #
 # images_path: /var/lib/libvirt/images/
+
+##### vCenter Parameters
 
 # < vCenter Datacenter >
 # vCenter datacenter to deploy Nuage components
@@ -81,6 +95,8 @@ dns_server_list: [ "10.1.0.2", ]
 #
 # vcenter_ovftool: /usr/bin/ovftool
 
+########################
+
 # < SSH Public Key >
 # Full path to the public key file to be injected into Nuage components to enable passwordless connectivity for configuration
 #
@@ -106,6 +122,8 @@ dns_server_list: [ "10.1.0.2", ]
 #
 # branding_zip_file:
 
+##### Yum
+
 # < Yum update >
 # Flag to indicate whether to perform a Yum update on VSD during the installation
 #
@@ -116,10 +134,14 @@ dns_server_list: [ "10.1.0.2", ]
 #
 # yum_proxy: NONE
 
+#########
+
 # < Nuage Software Version >
 # Nuage software version being installed. Optional for version comparison to skip deployment of some components that have already been installed.
 #
 # nuage_software_version:
+
+##### PoC Parameters
 
 # < VSD Disk Size >
 # Amount of VSD disk space to allocate, in GB. Valid only for KVM deployments. Note: Changing the default value is not a supported configuration.
@@ -146,6 +168,10 @@ dns_server_list: [ "10.1.0.2", ]
 #
 # vstat_ram: 16777216
 
+####################
+
+##### VSD Authentication
+
 # < VSD Architect URL >
 # VSD Architect URL. Required for tasks during Upgrade, Health Checks etc
 #
@@ -156,6 +182,10 @@ dns_server_list: [ "10.1.0.2", ]
 #
 # vsd_auth_enterprise: csp
 
+########################
+
+##### VCIN Authentication
+
 # < VCIN URL >
 # VCIN URL used for API interaction. Required for tasks like VRS-E upgrade (through VCIN)
 #
@@ -165,6 +195,10 @@ dns_server_list: [ "10.1.0.2", ]
 # Enterprise name used for authentication with VCIN. Required for tasks like VRS-E upgrade (through VCIN)
 #
 # vcin_auth_enterprise: csp
+
+#########################
+
+##### Libnetwork
 
 # < Libnetwork scope >
 # Scope of libnetworking support; local: connectivity between containers is limited to within the local host; global: connectivity between containers may span across hosts in the cluster
@@ -186,3 +220,5 @@ dns_server_list: [ "10.1.0.2", ]
 # Port portion of the URL pointing to the key-value store used for the Libnetwork cluster
 #
 # libnetwork_cluster_store_port: 8500
+
+################

--- a/examples/kvm_vsd_install/vsds.yml
+++ b/examples/kvm_vsd_install/vsds.yml
@@ -12,6 +12,8 @@
 # VSD 1
 #
 -
+    ##### Management Interface
+
     # < Hostname >
     # VSD Hostname
     #
@@ -32,6 +34,8 @@
     #
     mgmt_gateway: "192.168.110.1"
 
+    ##########################
+
     # < VM name >
     # Name of the Virtual Machine on the Hypervisor
     #
@@ -41,6 +45,8 @@
     # Virtual Machine name of the new VSD. Used during Upgrade only
     #
     # upgrade_vmname: ""
+
+    ##### Target Server
 
     # < Target Server Type >
     # Type of hypervisor environment into which the instance will be created
@@ -53,10 +59,14 @@
     #
     target_server: "10.105.1.102"
 
+    ###################
+
     # < Management Network Bridge >
     # Network Bridge used for the management interface of a component or the BOF interface on VSC. This will be a Distributed Virtual PortGroup (DVPG) when deploying on vCenter or a Linux network bridge when deploying on KVM. This field can be overridden by defining the management network bridge separately in the component configuration. Defaults to the global setting
     #
     # mgmt_bridge: (global Bridge interface)
+
+    ##### vCenter Parameters
 
     # < vCenter Datacenter Name >
     # Name of the vCenter Datacenter on which the VSD VM will be deployed. Defaults to the common vCenter Datacenter Name if not defined here.
@@ -72,6 +82,10 @@
     # Name of the vCenter Datastore on which the VSD VM will be deployed. Defaults to the common vCenter Datastore Name if not defined here.
     #
     # vcenter_datastore: (global vCenter Datastore Name)
+
+    ########################
+
+    ##### AWS Parameters
 
     # < AWS Region >
     # Only applicable for AWS deployments
@@ -102,6 +116,8 @@
     # ENI ID for VSD Instance on Management Subnet
     #
     # aws_mgmt_eni: ""
+
+    ####################
 
 
 

--- a/examples/upgrade_datacenter_vcenter/common.yml
+++ b/examples/upgrade_datacenter_vcenter/common.yml
@@ -11,6 +11,8 @@
 #
 nuage_unzipped_files_dir: "/my/unzipped/filedir"
 
+##### Management Interface
+
 # < Domain Name >
 # Domain name for this deployment. E.g. company.net.
 #
@@ -20,6 +22,10 @@ dns_domain: "company.com"
 # For clustered VSD, the XMPP FQDN for the cluster; For standalone VSD, the FQDN of the single VSD
 #
 vsd_fqdn_global: "vsd1.company.com"
+
+##########################
+
+##### Network Bridges
 
 # < Management Network Bridge >
 # Network Bridge used for the management interface of a component or the BOF interface on VSC. This will be a Distributed Virtual PortGroup (DVPG) when deploying on vCenter or a Linux network bridge when deploying on KVM. This field can be overridden by defining the management network bridge separately in the component configuration
@@ -36,6 +42,10 @@ data_bridge: "192.168.110.2"
 #
 # access_bridge:
 
+#####################
+
+##### Network Services
+
 # < NTP Server IP(s) >
 # List of one or more NTP server IPv4 addresses that must be in dotted-decimal format
 #
@@ -46,6 +56,8 @@ ntp_server_list: [ "5.5.5.5", "2.2.2.2", ]
 #
 dns_server_list: [ "10.1.0.2", ]
 
+######################
+
 # < Timezone >
 # Timezone specification for the deployment
 #
@@ -55,6 +67,8 @@ dns_server_list: [ "10.1.0.2", ]
 # Full path to the directory on the KVM target server where qcow2 files will be copied
 #
 # images_path: /var/lib/libvirt/images/
+
+##### vCenter Parameters
 
 # < vCenter Datacenter >
 # vCenter datacenter to deploy Nuage components
@@ -81,6 +95,8 @@ vcenter_datastore: "datastoreA"
 #
 vcenter_ovftool: "/usr/bin/ovftool"
 
+########################
+
 # < SSH Public Key >
 # Full path to the public key file to be injected into Nuage components to enable passwordless connectivity for configuration
 #
@@ -106,6 +122,8 @@ vcenter_ovftool: "/usr/bin/ovftool"
 #
 # branding_zip_file:
 
+##### Yum
+
 # < Yum update >
 # Flag to indicate whether to perform a Yum update on VSD during the installation
 #
@@ -116,10 +134,14 @@ vcenter_ovftool: "/usr/bin/ovftool"
 #
 # yum_proxy: NONE
 
+#########
+
 # < Nuage Software Version >
 # Nuage software version being installed. Optional for version comparison to skip deployment of some components that have already been installed.
 #
 # nuage_software_version:
+
+##### PoC Parameters
 
 # < VSD Disk Size >
 # Amount of VSD disk space to allocate, in GB. Valid only for KVM deployments. Note: Changing the default value is not a supported configuration.
@@ -146,6 +168,10 @@ vcenter_ovftool: "/usr/bin/ovftool"
 #
 # vstat_ram: 16777216
 
+####################
+
+##### VSD Authentication
+
 # < VSD Architect URL >
 # VSD Architect URL. Required for tasks during Upgrade, Health Checks etc
 #
@@ -156,6 +182,10 @@ vcenter_ovftool: "/usr/bin/ovftool"
 #
 # vsd_auth_enterprise: csp
 
+########################
+
+##### VCIN Authentication
+
 # < VCIN URL >
 # VCIN URL used for API interaction. Required for tasks like VRS-E upgrade (through VCIN)
 #
@@ -165,6 +195,10 @@ vcenter_ovftool: "/usr/bin/ovftool"
 # Enterprise name used for authentication with VCIN. Required for tasks like VRS-E upgrade (through VCIN)
 #
 # vcin_auth_enterprise: csp
+
+#########################
+
+##### Libnetwork
 
 # < Libnetwork scope >
 # Scope of libnetworking support; local: connectivity between containers is limited to within the local host; global: connectivity between containers may span across hosts in the cluster
@@ -186,3 +220,5 @@ vcenter_ovftool: "/usr/bin/ovftool"
 # Port portion of the URL pointing to the key-value store used for the Libnetwork cluster
 #
 # libnetwork_cluster_store_port: 8500
+
+################

--- a/examples/upgrade_datacenter_vcenter/credentials.yml
+++ b/examples/upgrade_datacenter_vcenter/credentials.yml
@@ -61,6 +61,8 @@ vcenter_password: "pass"
 #
 # vstat_custom_password:
 
+##### Custom VSD Passwords
+
 # < VSD cna Password >
 # Custom VSD cna password
 #
@@ -111,6 +113,10 @@ vcenter_password: "pass"
 #
 # vsd_keyserverstore_password:
 
+##########################
+
+##### AWS Credentials
+
 # < AWS Access key >
 # Access key for AWS
 #
@@ -120,3 +126,5 @@ vcenter_password: "pass"
 # Secret key for AWS
 #
 # aws_secret_key:
+
+#####################

--- a/examples/upgrade_datacenter_vcenter/vrss.yml
+++ b/examples/upgrade_datacenter_vcenter/vrss.yml
@@ -12,6 +12,8 @@
 # VRS 1
 #
 -
+    ##### Compute Nodes
+
     # < VRS Hypervisor OS type >
     # Hypervisor type for VRS installation
     # (u16.04, el7) 
@@ -23,6 +25,10 @@
     #
     vrs_ip_list: [ "192.168.110.50", "192.168.110.51", ]
 
+    ###################
+
+    ##### Controller Configuration
+
     # < Active Controller IP address >
     # Primary/Active Controller IP address
     #
@@ -32,6 +38,8 @@
     # Secondary/Standby Controller IP address
     #
     standby_controller_ip: "192.168.110.21"
+
+    ##############################
 
     # < DKMS install >
     # Optional DKMS module installation for MPLSoGRE tunnel type
@@ -48,6 +56,8 @@
 # VRS 2
 #
 -
+    ##### Compute Nodes
+
     # < VRS Hypervisor OS type >
     # Hypervisor type for VRS installation
     # (u16.04, el7) 
@@ -59,6 +69,10 @@
     #
     vrs_ip_list: [ "192.168.110.52", "192.168.110.53", ]
 
+    ###################
+
+    ##### Controller Configuration
+
     # < Active Controller IP address >
     # Primary/Active Controller IP address
     #
@@ -68,6 +82,8 @@
     # Secondary/Standby Controller IP address
     #
     standby_controller_ip: "192.168.110.21"
+
+    ##############################
 
     # < DKMS install >
     # Optional DKMS module installation for MPLSoGRE tunnel type
@@ -84,6 +100,8 @@
 # VRS 3
 #
 -
+    ##### Compute Nodes
+
     # < VRS Hypervisor OS type >
     # Hypervisor type for VRS installation
     # (u16.04, el7) 
@@ -95,6 +113,10 @@
     #
     vrs_ip_list: [ "192.168.110.54", ]
 
+    ###################
+
+    ##### Controller Configuration
+
     # < Active Controller IP address >
     # Primary/Active Controller IP address
     #
@@ -104,6 +126,8 @@
     # Secondary/Standby Controller IP address
     #
     standby_controller_ip: "192.168.110.21"
+
+    ##############################
 
     # < DKMS install >
     # Optional DKMS module installation for MPLSoGRE tunnel type

--- a/examples/upgrade_datacenter_vcenter/vscs.yml
+++ b/examples/upgrade_datacenter_vcenter/vscs.yml
@@ -12,6 +12,8 @@
 # VSC 1
 #
 -
+    ##### Management Network
+
     # < Hostname >
     # Hostname of the VSC instance
     #
@@ -32,6 +34,10 @@
     #
     mgmt_gateway: "192.168.110.1"
 
+    ########################
+
+    ##### Control Network
+
     # < Control IP address >
     # The Control/Data IP address of the controller
     #
@@ -41,6 +47,8 @@
     # Control network prefix length
     #
     ctrl_ip_prefix: 24
+
+    #####################
 
     # < System IP address >
     # Required for BGP pairing with peers
@@ -62,6 +70,8 @@
     #
     # mgmt_static_route_list: [ 0.0.0.0/1, 128.0.0.0/1 ]
 
+    ##### Target Server
+
     # < Target Server type >
     # Type of hypervisor environment into which the instance will be created
     # (kvm, vcenter, heat, aws) 
@@ -73,6 +83,8 @@
     #
     target_server: "10.105.1.100"
 
+    ###################
+
     # < Management Network Bridge >
     # Network Bridge used for the management interface of a component or the BOF interface on VSC. This will be a Distributed Virtual PortGroup (DVPG) when deploying on vCenter or a Linux network bridge when deploying on KVM. This field can be overridden by defining the management network bridge separately in the component configuration. Defaults to the global setting
     #
@@ -82,6 +94,8 @@
     # FQDN of the VSD or VSD cluster for this VSC
     #
     # vsd_fqdn: ""
+
+    ##### vCenter Parameters
 
     # < vCenter Datacenter Name >
     # Name of the vCenter Datacenter on which the VSC VM will be deployed. Defaults to the common vCenter Datacenter Name if not defined here.
@@ -97,6 +111,10 @@
     # Name of the vCenter Datastore on which the VSC VM will be deployed. Defaults to the common vCenter Datastore Name if not defined here.
     #
     vcenter_datastore: "datastoreA"
+
+    ########################
+
+    ##### Health Parameters
 
     # < Expected number of BGP neighbors >
     # Used in postdeploy and health workflows as expected values if non-zero
@@ -123,6 +141,10 @@
     #
     # expected_num_gateway_ports: 0
 
+    #######################
+
+    ##### AWS Parameters
+
     # < Private Management IP >
     # Private Management IP Address of VSC Instances on AWS
     #
@@ -143,11 +165,15 @@
     #
     # internal_ctrl_ip: ""
 
+    ####################
+
 
 #
 # VSC 2
 #
 -
+    ##### Management Network
+
     # < Hostname >
     # Hostname of the VSC instance
     #
@@ -168,6 +194,10 @@
     #
     mgmt_gateway: "192.168.110.1"
 
+    ########################
+
+    ##### Control Network
+
     # < Control IP address >
     # The Control/Data IP address of the controller
     #
@@ -177,6 +207,8 @@
     # Control network prefix length
     #
     ctrl_ip_prefix: 24
+
+    #####################
 
     # < System IP address >
     # Required for BGP pairing with peers
@@ -198,6 +230,8 @@
     #
     # mgmt_static_route_list: [ 0.0.0.0/1, 128.0.0.0/1 ]
 
+    ##### Target Server
+
     # < Target Server type >
     # Type of hypervisor environment into which the instance will be created
     # (kvm, vcenter, heat, aws) 
@@ -209,6 +243,8 @@
     #
     target_server: "10.105.1.101"
 
+    ###################
+
     # < Management Network Bridge >
     # Network Bridge used for the management interface of a component or the BOF interface on VSC. This will be a Distributed Virtual PortGroup (DVPG) when deploying on vCenter or a Linux network bridge when deploying on KVM. This field can be overridden by defining the management network bridge separately in the component configuration. Defaults to the global setting
     #
@@ -218,6 +254,8 @@
     # FQDN of the VSD or VSD cluster for this VSC
     #
     # vsd_fqdn: ""
+
+    ##### vCenter Parameters
 
     # < vCenter Datacenter Name >
     # Name of the vCenter Datacenter on which the VSC VM will be deployed. Defaults to the common vCenter Datacenter Name if not defined here.
@@ -233,6 +271,10 @@
     # Name of the vCenter Datastore on which the VSC VM will be deployed. Defaults to the common vCenter Datastore Name if not defined here.
     #
     vcenter_datastore: "datastoreB"
+
+    ########################
+
+    ##### Health Parameters
 
     # < Expected number of BGP neighbors >
     # Used in postdeploy and health workflows as expected values if non-zero
@@ -259,6 +301,10 @@
     #
     # expected_num_gateway_ports: 0
 
+    #######################
+
+    ##### AWS Parameters
+
     # < Private Management IP >
     # Private Management IP Address of VSC Instances on AWS
     #
@@ -278,6 +324,8 @@
     # Control IP Address of VSC Instances on AWS
     #
     # internal_ctrl_ip: ""
+
+    ####################
 
 
 

--- a/examples/upgrade_datacenter_vcenter/vsds.yml
+++ b/examples/upgrade_datacenter_vcenter/vsds.yml
@@ -12,6 +12,8 @@
 # VSD 1
 #
 -
+    ##### Management Interface
+
     # < Hostname >
     # VSD Hostname
     #
@@ -32,6 +34,8 @@
     #
     mgmt_gateway: "192.168.110.1"
 
+    ##########################
+
     # < VM name >
     # Name of the Virtual Machine on the Hypervisor
     #
@@ -41,6 +45,8 @@
     # Virtual Machine name of the new VSD. Used during Upgrade only
     #
     # upgrade_vmname: ""
+
+    ##### Target Server
 
     # < Target Server Type >
     # Type of hypervisor environment into which the instance will be created
@@ -53,10 +59,14 @@
     #
     target_server: "10.105.1.102"
 
+    ###################
+
     # < Management Network Bridge >
     # Network Bridge used for the management interface of a component or the BOF interface on VSC. This will be a Distributed Virtual PortGroup (DVPG) when deploying on vCenter or a Linux network bridge when deploying on KVM. This field can be overridden by defining the management network bridge separately in the component configuration. Defaults to the global setting
     #
     # mgmt_bridge: (global Bridge interface)
+
+    ##### vCenter Parameters
 
     # < vCenter Datacenter Name >
     # Name of the vCenter Datacenter on which the VSD VM will be deployed. Defaults to the common vCenter Datacenter Name if not defined here.
@@ -72,6 +82,10 @@
     # Name of the vCenter Datastore on which the VSD VM will be deployed. Defaults to the common vCenter Datastore Name if not defined here.
     #
     vcenter_datastore: "datastoreA"
+
+    ########################
+
+    ##### AWS Parameters
 
     # < AWS Region >
     # Only applicable for AWS deployments
@@ -103,11 +117,15 @@
     #
     # aws_mgmt_eni: ""
 
+    ####################
+
 
 #
 # VSD 2
 #
 -
+    ##### Management Interface
+
     # < Hostname >
     # VSD Hostname
     #
@@ -128,6 +146,8 @@
     #
     mgmt_gateway: "192.168.110.1"
 
+    ##########################
+
     # < VM name >
     # Name of the Virtual Machine on the Hypervisor
     #
@@ -137,6 +157,8 @@
     # Virtual Machine name of the new VSD. Used during Upgrade only
     #
     # upgrade_vmname: ""
+
+    ##### Target Server
 
     # < Target Server Type >
     # Type of hypervisor environment into which the instance will be created
@@ -149,10 +171,14 @@
     #
     target_server: "10.105.1.103"
 
+    ###################
+
     # < Management Network Bridge >
     # Network Bridge used for the management interface of a component or the BOF interface on VSC. This will be a Distributed Virtual PortGroup (DVPG) when deploying on vCenter or a Linux network bridge when deploying on KVM. This field can be overridden by defining the management network bridge separately in the component configuration. Defaults to the global setting
     #
     # mgmt_bridge: (global Bridge interface)
+
+    ##### vCenter Parameters
 
     # < vCenter Datacenter Name >
     # Name of the vCenter Datacenter on which the VSD VM will be deployed. Defaults to the common vCenter Datacenter Name if not defined here.
@@ -168,6 +194,10 @@
     # Name of the vCenter Datastore on which the VSD VM will be deployed. Defaults to the common vCenter Datastore Name if not defined here.
     #
     vcenter_datastore: "datastoreA"
+
+    ########################
+
+    ##### AWS Parameters
 
     # < AWS Region >
     # Only applicable for AWS deployments
@@ -199,11 +229,15 @@
     #
     # aws_mgmt_eni: ""
 
+    ####################
+
 
 #
 # VSD 3
 #
 -
+    ##### Management Interface
+
     # < Hostname >
     # VSD Hostname
     #
@@ -224,6 +258,8 @@
     #
     mgmt_gateway: "192.168.110.1"
 
+    ##########################
+
     # < VM name >
     # Name of the Virtual Machine on the Hypervisor
     #
@@ -233,6 +269,8 @@
     # Virtual Machine name of the new VSD. Used during Upgrade only
     #
     # upgrade_vmname: ""
+
+    ##### Target Server
 
     # < Target Server Type >
     # Type of hypervisor environment into which the instance will be created
@@ -245,10 +283,14 @@
     #
     target_server: "10.105.1.104"
 
+    ###################
+
     # < Management Network Bridge >
     # Network Bridge used for the management interface of a component or the BOF interface on VSC. This will be a Distributed Virtual PortGroup (DVPG) when deploying on vCenter or a Linux network bridge when deploying on KVM. This field can be overridden by defining the management network bridge separately in the component configuration. Defaults to the global setting
     #
     # mgmt_bridge: (global Bridge interface)
+
+    ##### vCenter Parameters
 
     # < vCenter Datacenter Name >
     # Name of the vCenter Datacenter on which the VSD VM will be deployed. Defaults to the common vCenter Datacenter Name if not defined here.
@@ -264,6 +306,10 @@
     # Name of the vCenter Datastore on which the VSD VM will be deployed. Defaults to the common vCenter Datastore Name if not defined here.
     #
     vcenter_datastore: "datastoreB"
+
+    ########################
+
+    ##### AWS Parameters
 
     # < AWS Region >
     # Only applicable for AWS deployments
@@ -294,6 +340,8 @@
     # ENI ID for VSD Instance on Management Subnet
     #
     # aws_mgmt_eni: ""
+
+    ####################
 
 
 

--- a/examples/upgrade_datacenter_vcenter/vstats.yml
+++ b/examples/upgrade_datacenter_vcenter/vstats.yml
@@ -12,6 +12,8 @@
 # VSTAT 1
 #
 -
+    ##### Management Interface
+
     # < Hostname >
     # Management network host name for the VSTAT
     #
@@ -32,6 +34,8 @@
     #
     mgmt_gateway: "192.168.110.1"
 
+    ##########################
+
     # < VM name >
     # Name of the Virtual Machine on the Hypervisor
     #
@@ -41,6 +45,8 @@
     # Virtual Machine name of the new Stats VM. Used during Upgrade only
     #
     # upgrade_vmname: ""
+
+    ##### Target Server
 
     # < Target Server type >
     # Type of hypervisor environment into which the instance will be created
@@ -53,6 +59,8 @@
     #
     target_server: "10.105.1.105"
 
+    ###################
+
     # < Management Network Bridge >
     # Network Bridge used for the management interface of a component or the BOF interface on VSC. This will be a Distributed Virtual PortGroup (DVPG) when deploying on vCenter or a Linux network bridge when deploying on KVM. This field can be overridden by defining the management network bridge separately in the component configuration. Defaults to the global setting
     #
@@ -62,6 +70,8 @@
     # FQDN of the VSD or VSD cluster for this VSTAT
     #
     # vsd_fqdn:
+
+    ##### vCenter Parameters
 
     # < vCenter Datacenter Name >
     # Name of the vCenter Datacenter on which the VSTAT VM will be deployed. Defaults to the common vCenter Datacenter Name if not defined here.
@@ -73,10 +83,14 @@
     #
     vcenter_cluster: "Cluster-A"
 
+    ##### vCenter Parameters
+
     # < vCenter Datastore Name >
     # Name of the vCenter Datastore on which the VSTAT VM will be deployed. Defaults to the common vCenter Datastore Name if not defined here.
     #
     vcenter_datastore: "datastoreA"
+
+    ##### AWS Parameters
 
     # < AWS AMI ID >
     # AMI ID for AWS instance
@@ -103,11 +117,15 @@
     #
     # aws_mgmt_eni: ""
 
+    ####################
+
 
 #
 # VSTAT 2
 #
 -
+    ##### Management Interface
+
     # < Hostname >
     # Management network host name for the VSTAT
     #
@@ -128,6 +146,8 @@
     #
     mgmt_gateway: "192.168.110.1"
 
+    ##########################
+
     # < VM name >
     # Name of the Virtual Machine on the Hypervisor
     #
@@ -137,6 +157,8 @@
     # Virtual Machine name of the new Stats VM. Used during Upgrade only
     #
     # upgrade_vmname: ""
+
+    ##### Target Server
 
     # < Target Server type >
     # Type of hypervisor environment into which the instance will be created
@@ -149,6 +171,8 @@
     #
     target_server: "10.105.1.106"
 
+    ###################
+
     # < Management Network Bridge >
     # Network Bridge used for the management interface of a component or the BOF interface on VSC. This will be a Distributed Virtual PortGroup (DVPG) when deploying on vCenter or a Linux network bridge when deploying on KVM. This field can be overridden by defining the management network bridge separately in the component configuration. Defaults to the global setting
     #
@@ -158,6 +182,8 @@
     # FQDN of the VSD or VSD cluster for this VSTAT
     #
     # vsd_fqdn:
+
+    ##### vCenter Parameters
 
     # < vCenter Datacenter Name >
     # Name of the vCenter Datacenter on which the VSTAT VM will be deployed. Defaults to the common vCenter Datacenter Name if not defined here.
@@ -169,10 +195,14 @@
     #
     vcenter_cluster: "Cluster-B"
 
+    ##### vCenter Parameters
+
     # < vCenter Datastore Name >
     # Name of the vCenter Datastore on which the VSTAT VM will be deployed. Defaults to the common vCenter Datastore Name if not defined here.
     #
     vcenter_datastore: "datastoreB"
+
+    ##### AWS Parameters
 
     # < AWS AMI ID >
     # AMI ID for AWS instance
@@ -198,6 +228,8 @@
     # ENI ID for VSTAT Instance on Management Subnetwork
     #
     # aws_mgmt_eni: ""
+
+    ####################
 
 
 

--- a/examples/vcenter_datacenter_install/common.yml
+++ b/examples/vcenter_datacenter_install/common.yml
@@ -11,6 +11,8 @@
 #
 nuage_unzipped_files_dir: "/my/unzipped/filedir"
 
+##### Management Interface
+
 # < Domain Name >
 # Domain name for this deployment. E.g. company.net.
 #
@@ -20,6 +22,10 @@ dns_domain: "company.com"
 # For clustered VSD, the XMPP FQDN for the cluster; For standalone VSD, the FQDN of the single VSD
 #
 vsd_fqdn_global: "vsd1.company.com"
+
+##########################
+
+##### Network Bridges
 
 # < Management Network Bridge >
 # Network Bridge used for the management interface of a component or the BOF interface on VSC. This will be a Distributed Virtual PortGroup (DVPG) when deploying on vCenter or a Linux network bridge when deploying on KVM. This field can be overridden by defining the management network bridge separately in the component configuration
@@ -36,6 +42,10 @@ data_bridge: "192.168.110.2"
 #
 # access_bridge:
 
+#####################
+
+##### Network Services
+
 # < NTP Server IP(s) >
 # List of one or more NTP server IPv4 addresses that must be in dotted-decimal format
 #
@@ -46,6 +56,8 @@ ntp_server_list: [ "5.5.5.5", "2.2.2.2", ]
 #
 dns_server_list: [ "10.1.0.2", ]
 
+######################
+
 # < Timezone >
 # Timezone specification for the deployment
 #
@@ -55,6 +67,8 @@ dns_server_list: [ "10.1.0.2", ]
 # Full path to the directory on the KVM target server where qcow2 files will be copied
 #
 # images_path: /var/lib/libvirt/images/
+
+##### vCenter Parameters
 
 # < vCenter Datacenter >
 # vCenter datacenter to deploy Nuage components
@@ -81,6 +95,8 @@ vcenter_datastore: "datastoreA"
 #
 vcenter_ovftool: "/usr/bin/ovftool"
 
+########################
+
 # < SSH Public Key >
 # Full path to the public key file to be injected into Nuage components to enable passwordless connectivity for configuration
 #
@@ -106,6 +122,8 @@ vcenter_ovftool: "/usr/bin/ovftool"
 #
 # branding_zip_file:
 
+##### Yum
+
 # < Yum update >
 # Flag to indicate whether to perform a Yum update on VSD during the installation
 #
@@ -116,10 +134,14 @@ vcenter_ovftool: "/usr/bin/ovftool"
 #
 # yum_proxy: NONE
 
+#########
+
 # < Nuage Software Version >
 # Nuage software version being installed. Optional for version comparison to skip deployment of some components that have already been installed.
 #
 # nuage_software_version:
+
+##### PoC Parameters
 
 # < VSD Disk Size >
 # Amount of VSD disk space to allocate, in GB. Valid only for KVM deployments. Note: Changing the default value is not a supported configuration.
@@ -146,6 +168,10 @@ vcenter_ovftool: "/usr/bin/ovftool"
 #
 # vstat_ram: 16777216
 
+####################
+
+##### VSD Authentication
+
 # < VSD Architect URL >
 # VSD Architect URL. Required for tasks during Upgrade, Health Checks etc
 #
@@ -156,6 +182,10 @@ vcenter_ovftool: "/usr/bin/ovftool"
 #
 # vsd_auth_enterprise: csp
 
+########################
+
+##### VCIN Authentication
+
 # < VCIN URL >
 # VCIN URL used for API interaction. Required for tasks like VRS-E upgrade (through VCIN)
 #
@@ -165,6 +195,10 @@ vcenter_ovftool: "/usr/bin/ovftool"
 # Enterprise name used for authentication with VCIN. Required for tasks like VRS-E upgrade (through VCIN)
 #
 # vcin_auth_enterprise: csp
+
+#########################
+
+##### Libnetwork
 
 # < Libnetwork scope >
 # Scope of libnetworking support; local: connectivity between containers is limited to within the local host; global: connectivity between containers may span across hosts in the cluster
@@ -186,3 +220,5 @@ vcenter_ovftool: "/usr/bin/ovftool"
 # Port portion of the URL pointing to the key-value store used for the Libnetwork cluster
 #
 # libnetwork_cluster_store_port: 8500
+
+################

--- a/examples/vcenter_datacenter_install/credentials.yml
+++ b/examples/vcenter_datacenter_install/credentials.yml
@@ -61,6 +61,8 @@ vcenter_password: "pass"
 #
 # vstat_custom_password:
 
+##### Custom VSD Passwords
+
 # < VSD cna Password >
 # Custom VSD cna password
 #
@@ -111,6 +113,10 @@ vcenter_password: "pass"
 #
 # vsd_keyserverstore_password:
 
+##########################
+
+##### AWS Credentials
+
 # < AWS Access key >
 # Access key for AWS
 #
@@ -120,3 +126,5 @@ vcenter_password: "pass"
 # Secret key for AWS
 #
 # aws_secret_key:
+
+#####################

--- a/examples/vcenter_datacenter_install/vrss.yml
+++ b/examples/vcenter_datacenter_install/vrss.yml
@@ -12,6 +12,8 @@
 # VRS 1
 #
 -
+    ##### Compute Nodes
+
     # < VRS Hypervisor OS type >
     # Hypervisor type for VRS installation
     # (u16.04, el7) 
@@ -23,6 +25,10 @@
     #
     vrs_ip_list: [ "192.168.110.50", "192.168.110.51", ]
 
+    ###################
+
+    ##### Controller Configuration
+
     # < Active Controller IP address >
     # Primary/Active Controller IP address
     #
@@ -32,6 +38,8 @@
     # Secondary/Standby Controller IP address
     #
     standby_controller_ip: "192.168.110.21"
+
+    ##############################
 
     # < DKMS install >
     # Optional DKMS module installation for MPLSoGRE tunnel type
@@ -48,6 +56,8 @@
 # VRS 2
 #
 -
+    ##### Compute Nodes
+
     # < VRS Hypervisor OS type >
     # Hypervisor type for VRS installation
     # (u16.04, el7) 
@@ -59,6 +69,10 @@
     #
     vrs_ip_list: [ "192.168.110.52", "192.168.110.53", ]
 
+    ###################
+
+    ##### Controller Configuration
+
     # < Active Controller IP address >
     # Primary/Active Controller IP address
     #
@@ -68,6 +82,8 @@
     # Secondary/Standby Controller IP address
     #
     standby_controller_ip: "192.168.110.21"
+
+    ##############################
 
     # < DKMS install >
     # Optional DKMS module installation for MPLSoGRE tunnel type
@@ -84,6 +100,8 @@
 # VRS 3
 #
 -
+    ##### Compute Nodes
+
     # < VRS Hypervisor OS type >
     # Hypervisor type for VRS installation
     # (u16.04, el7) 
@@ -95,6 +113,10 @@
     #
     vrs_ip_list: [ "192.168.110.54", ]
 
+    ###################
+
+    ##### Controller Configuration
+
     # < Active Controller IP address >
     # Primary/Active Controller IP address
     #
@@ -104,6 +126,8 @@
     # Secondary/Standby Controller IP address
     #
     standby_controller_ip: "192.168.110.21"
+
+    ##############################
 
     # < DKMS install >
     # Optional DKMS module installation for MPLSoGRE tunnel type

--- a/examples/vcenter_datacenter_install/vscs.yml
+++ b/examples/vcenter_datacenter_install/vscs.yml
@@ -12,6 +12,8 @@
 # VSC 1
 #
 -
+    ##### Management Network
+
     # < Hostname >
     # Hostname of the VSC instance
     #
@@ -32,6 +34,10 @@
     #
     mgmt_gateway: "192.168.110.1"
 
+    ########################
+
+    ##### Control Network
+
     # < Control IP address >
     # The Control/Data IP address of the controller
     #
@@ -41,6 +47,8 @@
     # Control network prefix length
     #
     ctrl_ip_prefix: 24
+
+    #####################
 
     # < System IP address >
     # Required for BGP pairing with peers
@@ -62,6 +70,8 @@
     #
     # mgmt_static_route_list: [ 0.0.0.0/1, 128.0.0.0/1 ]
 
+    ##### Target Server
+
     # < Target Server type >
     # Type of hypervisor environment into which the instance will be created
     # (kvm, vcenter, heat, aws) 
@@ -73,6 +83,8 @@
     #
     target_server: "10.105.1.100"
 
+    ###################
+
     # < Management Network Bridge >
     # Network Bridge used for the management interface of a component or the BOF interface on VSC. This will be a Distributed Virtual PortGroup (DVPG) when deploying on vCenter or a Linux network bridge when deploying on KVM. This field can be overridden by defining the management network bridge separately in the component configuration. Defaults to the global setting
     #
@@ -82,6 +94,8 @@
     # FQDN of the VSD or VSD cluster for this VSC
     #
     # vsd_fqdn: ""
+
+    ##### vCenter Parameters
 
     # < vCenter Datacenter Name >
     # Name of the vCenter Datacenter on which the VSC VM will be deployed. Defaults to the common vCenter Datacenter Name if not defined here.
@@ -97,6 +111,10 @@
     # Name of the vCenter Datastore on which the VSC VM will be deployed. Defaults to the common vCenter Datastore Name if not defined here.
     #
     vcenter_datastore: "datastoreA"
+
+    ########################
+
+    ##### Health Parameters
 
     # < Expected number of BGP neighbors >
     # Used in postdeploy and health workflows as expected values if non-zero
@@ -123,6 +141,10 @@
     #
     # expected_num_gateway_ports: 0
 
+    #######################
+
+    ##### AWS Parameters
+
     # < Private Management IP >
     # Private Management IP Address of VSC Instances on AWS
     #
@@ -143,11 +165,15 @@
     #
     # internal_ctrl_ip: ""
 
+    ####################
+
 
 #
 # VSC 2
 #
 -
+    ##### Management Network
+
     # < Hostname >
     # Hostname of the VSC instance
     #
@@ -168,6 +194,10 @@
     #
     mgmt_gateway: "192.168.110.1"
 
+    ########################
+
+    ##### Control Network
+
     # < Control IP address >
     # The Control/Data IP address of the controller
     #
@@ -177,6 +207,8 @@
     # Control network prefix length
     #
     ctrl_ip_prefix: 24
+
+    #####################
 
     # < System IP address >
     # Required for BGP pairing with peers
@@ -198,6 +230,8 @@
     #
     # mgmt_static_route_list: [ 0.0.0.0/1, 128.0.0.0/1 ]
 
+    ##### Target Server
+
     # < Target Server type >
     # Type of hypervisor environment into which the instance will be created
     # (kvm, vcenter, heat, aws) 
@@ -209,6 +243,8 @@
     #
     target_server: "10.105.1.101"
 
+    ###################
+
     # < Management Network Bridge >
     # Network Bridge used for the management interface of a component or the BOF interface on VSC. This will be a Distributed Virtual PortGroup (DVPG) when deploying on vCenter or a Linux network bridge when deploying on KVM. This field can be overridden by defining the management network bridge separately in the component configuration. Defaults to the global setting
     #
@@ -218,6 +254,8 @@
     # FQDN of the VSD or VSD cluster for this VSC
     #
     # vsd_fqdn: ""
+
+    ##### vCenter Parameters
 
     # < vCenter Datacenter Name >
     # Name of the vCenter Datacenter on which the VSC VM will be deployed. Defaults to the common vCenter Datacenter Name if not defined here.
@@ -233,6 +271,10 @@
     # Name of the vCenter Datastore on which the VSC VM will be deployed. Defaults to the common vCenter Datastore Name if not defined here.
     #
     vcenter_datastore: "datastoreB"
+
+    ########################
+
+    ##### Health Parameters
 
     # < Expected number of BGP neighbors >
     # Used in postdeploy and health workflows as expected values if non-zero
@@ -259,6 +301,10 @@
     #
     # expected_num_gateway_ports: 0
 
+    #######################
+
+    ##### AWS Parameters
+
     # < Private Management IP >
     # Private Management IP Address of VSC Instances on AWS
     #
@@ -278,6 +324,8 @@
     # Control IP Address of VSC Instances on AWS
     #
     # internal_ctrl_ip: ""
+
+    ####################
 
 
 

--- a/examples/vcenter_datacenter_install/vsds.yml
+++ b/examples/vcenter_datacenter_install/vsds.yml
@@ -12,6 +12,8 @@
 # VSD 1
 #
 -
+    ##### Management Interface
+
     # < Hostname >
     # VSD Hostname
     #
@@ -32,6 +34,8 @@
     #
     mgmt_gateway: "192.168.110.1"
 
+    ##########################
+
     # < VM name >
     # Name of the Virtual Machine on the Hypervisor
     #
@@ -41,6 +45,8 @@
     # Virtual Machine name of the new VSD. Used during Upgrade only
     #
     # upgrade_vmname: ""
+
+    ##### Target Server
 
     # < Target Server Type >
     # Type of hypervisor environment into which the instance will be created
@@ -53,10 +59,14 @@
     #
     target_server: "10.105.1.102"
 
+    ###################
+
     # < Management Network Bridge >
     # Network Bridge used for the management interface of a component or the BOF interface on VSC. This will be a Distributed Virtual PortGroup (DVPG) when deploying on vCenter or a Linux network bridge when deploying on KVM. This field can be overridden by defining the management network bridge separately in the component configuration. Defaults to the global setting
     #
     # mgmt_bridge: (global Bridge interface)
+
+    ##### vCenter Parameters
 
     # < vCenter Datacenter Name >
     # Name of the vCenter Datacenter on which the VSD VM will be deployed. Defaults to the common vCenter Datacenter Name if not defined here.
@@ -72,6 +82,10 @@
     # Name of the vCenter Datastore on which the VSD VM will be deployed. Defaults to the common vCenter Datastore Name if not defined here.
     #
     vcenter_datastore: "datastoreA"
+
+    ########################
+
+    ##### AWS Parameters
 
     # < AWS Region >
     # Only applicable for AWS deployments
@@ -103,11 +117,15 @@
     #
     # aws_mgmt_eni: ""
 
+    ####################
+
 
 #
 # VSD 2
 #
 -
+    ##### Management Interface
+
     # < Hostname >
     # VSD Hostname
     #
@@ -128,6 +146,8 @@
     #
     mgmt_gateway: "192.168.110.1"
 
+    ##########################
+
     # < VM name >
     # Name of the Virtual Machine on the Hypervisor
     #
@@ -137,6 +157,8 @@
     # Virtual Machine name of the new VSD. Used during Upgrade only
     #
     # upgrade_vmname: ""
+
+    ##### Target Server
 
     # < Target Server Type >
     # Type of hypervisor environment into which the instance will be created
@@ -149,10 +171,14 @@
     #
     target_server: "10.105.1.103"
 
+    ###################
+
     # < Management Network Bridge >
     # Network Bridge used for the management interface of a component or the BOF interface on VSC. This will be a Distributed Virtual PortGroup (DVPG) when deploying on vCenter or a Linux network bridge when deploying on KVM. This field can be overridden by defining the management network bridge separately in the component configuration. Defaults to the global setting
     #
     # mgmt_bridge: (global Bridge interface)
+
+    ##### vCenter Parameters
 
     # < vCenter Datacenter Name >
     # Name of the vCenter Datacenter on which the VSD VM will be deployed. Defaults to the common vCenter Datacenter Name if not defined here.
@@ -168,6 +194,10 @@
     # Name of the vCenter Datastore on which the VSD VM will be deployed. Defaults to the common vCenter Datastore Name if not defined here.
     #
     vcenter_datastore: "datastoreA"
+
+    ########################
+
+    ##### AWS Parameters
 
     # < AWS Region >
     # Only applicable for AWS deployments
@@ -199,11 +229,15 @@
     #
     # aws_mgmt_eni: ""
 
+    ####################
+
 
 #
 # VSD 3
 #
 -
+    ##### Management Interface
+
     # < Hostname >
     # VSD Hostname
     #
@@ -224,6 +258,8 @@
     #
     mgmt_gateway: "192.168.110.1"
 
+    ##########################
+
     # < VM name >
     # Name of the Virtual Machine on the Hypervisor
     #
@@ -233,6 +269,8 @@
     # Virtual Machine name of the new VSD. Used during Upgrade only
     #
     # upgrade_vmname: ""
+
+    ##### Target Server
 
     # < Target Server Type >
     # Type of hypervisor environment into which the instance will be created
@@ -245,10 +283,14 @@
     #
     target_server: "10.105.1.104"
 
+    ###################
+
     # < Management Network Bridge >
     # Network Bridge used for the management interface of a component or the BOF interface on VSC. This will be a Distributed Virtual PortGroup (DVPG) when deploying on vCenter or a Linux network bridge when deploying on KVM. This field can be overridden by defining the management network bridge separately in the component configuration. Defaults to the global setting
     #
     # mgmt_bridge: (global Bridge interface)
+
+    ##### vCenter Parameters
 
     # < vCenter Datacenter Name >
     # Name of the vCenter Datacenter on which the VSD VM will be deployed. Defaults to the common vCenter Datacenter Name if not defined here.
@@ -264,6 +306,10 @@
     # Name of the vCenter Datastore on which the VSD VM will be deployed. Defaults to the common vCenter Datastore Name if not defined here.
     #
     vcenter_datastore: "datastoreB"
+
+    ########################
+
+    ##### AWS Parameters
 
     # < AWS Region >
     # Only applicable for AWS deployments
@@ -294,6 +340,8 @@
     # ENI ID for VSD Instance on Management Subnet
     #
     # aws_mgmt_eni: ""
+
+    ####################
 
 
 

--- a/examples/vcenter_datacenter_install/vstats.yml
+++ b/examples/vcenter_datacenter_install/vstats.yml
@@ -12,6 +12,8 @@
 # VSTAT 1
 #
 -
+    ##### Management Interface
+
     # < Hostname >
     # Management network host name for the VSTAT
     #
@@ -32,6 +34,8 @@
     #
     mgmt_gateway: "192.168.110.1"
 
+    ##########################
+
     # < VM name >
     # Name of the Virtual Machine on the Hypervisor
     #
@@ -41,6 +45,8 @@
     # Virtual Machine name of the new Stats VM. Used during Upgrade only
     #
     # upgrade_vmname: ""
+
+    ##### Target Server
 
     # < Target Server type >
     # Type of hypervisor environment into which the instance will be created
@@ -53,6 +59,8 @@
     #
     target_server: "10.105.1.105"
 
+    ###################
+
     # < Management Network Bridge >
     # Network Bridge used for the management interface of a component or the BOF interface on VSC. This will be a Distributed Virtual PortGroup (DVPG) when deploying on vCenter or a Linux network bridge when deploying on KVM. This field can be overridden by defining the management network bridge separately in the component configuration. Defaults to the global setting
     #
@@ -62,6 +70,8 @@
     # FQDN of the VSD or VSD cluster for this VSTAT
     #
     # vsd_fqdn:
+
+    ##### vCenter Parameters
 
     # < vCenter Datacenter Name >
     # Name of the vCenter Datacenter on which the VSTAT VM will be deployed. Defaults to the common vCenter Datacenter Name if not defined here.
@@ -73,10 +83,14 @@
     #
     vcenter_cluster: "Cluster-A"
 
+    ##### vCenter Parameters
+
     # < vCenter Datastore Name >
     # Name of the vCenter Datastore on which the VSTAT VM will be deployed. Defaults to the common vCenter Datastore Name if not defined here.
     #
     vcenter_datastore: "datastoreA"
+
+    ##### AWS Parameters
 
     # < AWS AMI ID >
     # AMI ID for AWS instance
@@ -103,11 +117,15 @@
     #
     # aws_mgmt_eni: ""
 
+    ####################
+
 
 #
 # VSTAT 2
 #
 -
+    ##### Management Interface
+
     # < Hostname >
     # Management network host name for the VSTAT
     #
@@ -128,6 +146,8 @@
     #
     mgmt_gateway: "192.168.110.1"
 
+    ##########################
+
     # < VM name >
     # Name of the Virtual Machine on the Hypervisor
     #
@@ -137,6 +157,8 @@
     # Virtual Machine name of the new Stats VM. Used during Upgrade only
     #
     # upgrade_vmname: ""
+
+    ##### Target Server
 
     # < Target Server type >
     # Type of hypervisor environment into which the instance will be created
@@ -149,6 +171,8 @@
     #
     target_server: "10.105.1.106"
 
+    ###################
+
     # < Management Network Bridge >
     # Network Bridge used for the management interface of a component or the BOF interface on VSC. This will be a Distributed Virtual PortGroup (DVPG) when deploying on vCenter or a Linux network bridge when deploying on KVM. This field can be overridden by defining the management network bridge separately in the component configuration. Defaults to the global setting
     #
@@ -158,6 +182,8 @@
     # FQDN of the VSD or VSD cluster for this VSTAT
     #
     # vsd_fqdn:
+
+    ##### vCenter Parameters
 
     # < vCenter Datacenter Name >
     # Name of the vCenter Datacenter on which the VSTAT VM will be deployed. Defaults to the common vCenter Datacenter Name if not defined here.
@@ -169,10 +195,14 @@
     #
     vcenter_cluster: "Cluster-B"
 
+    ##### vCenter Parameters
+
     # < vCenter Datastore Name >
     # Name of the vCenter Datastore on which the VSTAT VM will be deployed. Defaults to the common vCenter Datastore Name if not defined here.
     #
     vcenter_datastore: "datastoreB"
+
+    ##### AWS Parameters
 
     # < AWS AMI ID >
     # AMI ID for AWS instance
@@ -198,6 +228,8 @@
     # ENI ID for VSTAT Instance on Management Subnetwork
     #
     # aws_mgmt_eni: ""
+
+    ####################
 
 
 

--- a/generate_example_from_schema.py
+++ b/generate_example_from_schema.py
@@ -11,7 +11,8 @@ SCHEMA_DIRECTORY = "schemas"
 
 
 class ExampleFileGenerator(object):
-    def __init__(self, no_comments=False, as_template=False, as_example=False, example_folder=None):
+    def __init__(self, no_comments=False, as_template=False, as_example=False,
+                 example_folder=None):
         self.has_comments = not no_comments
         self.as_template = as_template | as_example
         self.as_example = as_example
@@ -28,13 +29,15 @@ class ExampleFileGenerator(object):
         self.add_example_content(schema)
 
         if self.as_example:
-            schema_name = os.path.splitext(os.path.basename(schema_filename))[0]
+            schema_name = os.path.splitext(os.path.basename(
+                schema_filename))[0]
             return self.create_example_with_data(schema_name)
 
         return "\n".join(self.example_lines)
 
     def create_example_with_data(self, schema_name=""):
-        with open(self.example_folder + "/" + schema_name + ".yml", 'r') as example_filename:
+        with open(self.example_folder +
+                  "/" + schema_name + ".yml", 'r') as example_filename:
             example_yml = yaml.safe_load(example_filename.read())
 
         template_lines = "\n".join(self.example_lines)
@@ -114,6 +117,11 @@ class ExampleFileGenerator(object):
             indent = "    "
 
         if self.has_comments:
+            if "sectionBegin" in field:
+                self.example_lines.append("%s##### %s" % (
+                    indent, field["sectionBegin"]))
+                self.example_lines.append("")
+
             if "title" in field:
                 self.example_lines.append("%s# < %s >" % (indent,
                                                           field["title"]))
@@ -162,6 +170,10 @@ class ExampleFileGenerator(object):
 
         if self.has_comments:
             self.example_lines.append("")
+            if "sectionEnd" in field:
+                self.example_lines.append(
+                    indent + ("#" * (len(field['sectionEnd']) + 6)))
+                self.example_lines.append("")
 
     def get_example_value(self, name, field, is_list):
         field_type = "string"
@@ -202,15 +214,21 @@ class ExampleFileGenerator(object):
 
 def main():
 
-    parser = argparse.ArgumentParser(description='Generate example from schema')
+    parser = argparse.ArgumentParser(
+        description='Generate example from schema')
     parser.add_argument("--schema", help="Schema file name")
-    parser.add_argument("--no-comments", dest="no_comments", action='store_true', default=False,
-                        help="Generates without title/usage description comments")
-    parser.add_argument("--as-template", dest="as_template", action='store_true', default=False,
-                        help="Generates as a jinja2 template")
-    parser.add_argument("--as-example", dest="as_example", action='store_true', default=False,
-                        help="Generates a example schema using example data")
-    parser.add_argument("--example_data_folder", help="Location of example data folder")
+    parser.add_argument(
+        "--no-comments", dest="no_comments",
+        action='store_true', default=False,
+        help="Generates without title/usage description comments")
+    parser.add_argument(
+        "--as-template", dest="as_template", action='store_true',
+        default=False, help="Generates as a jinja2 template")
+    parser.add_argument(
+        "--as-example", dest="as_example", action='store_true', default=False,
+        help="Generates a example schema using example data")
+    parser.add_argument(
+        "--example_data_folder", help="Location of example data folder")
     args = parser.parse_args()
 
     if not args.schema:
@@ -230,7 +248,8 @@ def main():
     as_example = args.as_example
     example_folder = args.example_data_folder
 
-    generator = ExampleFileGenerator(no_comments, as_template, as_example, example_folder)
+    generator = ExampleFileGenerator(no_comments, as_template, as_example,
+                                     example_folder)
 
     if schema_filename.find(".") == -1:
         schema_filename = schema_filename + ".json"

--- a/src/deployment_templates/common.j2
+++ b/src/deployment_templates/common.j2
@@ -11,6 +11,8 @@
 #
 nuage_unzipped_files_dir: "{{ nuage_unzipped_files_dir }}"
 
+##### Management Interface
+
 # < Domain Name >
 # Domain name for this deployment. E.g. company.net.
 #
@@ -20,6 +22,10 @@ dns_domain: "{{ dns_domain }}"
 # For clustered VSD, the XMPP FQDN for the cluster; For standalone VSD, the FQDN of the single VSD
 #
 vsd_fqdn_global: "{{ vsd_fqdn_global }}"
+
+##########################
+
+##### Network Bridges
 
 # < Management Network Bridge >
 # Network Bridge used for the management interface of a component or the BOF interface on VSC. This will be a Distributed Virtual PortGroup (DVPG) when deploying on vCenter or a Linux network bridge when deploying on KVM. This field can be overridden by defining the management network bridge separately in the component configuration
@@ -40,6 +46,10 @@ access_bridge: "{{ access_bridge }}"
 # access_bridge: 
 {%- endif %}
 
+#####################
+
+##### Network Services
+
 # < NTP Server IP(s) >
 # List of one or more NTP server IPv4 addresses that must be in dotted-decimal format
 #
@@ -49,6 +59,8 @@ ntp_server_list: [ {% for i in ntp_server_list | default([]) %}"{{ i }}", {% end
 # List of one or more DNS server IPv4 addresses for resolving component domain names. Must be in dotted-decimal format.
 #
 dns_server_list: [ {% for i in dns_server_list | default([]) %}"{{ i }}", {% endfor %}]
+
+######################
 
 # < Timezone >
 # Timezone specification for the deployment
@@ -67,6 +79,8 @@ images_path: "{{ images_path }}"
 {%- else %}
 # images_path: /var/lib/libvirt/images/
 {%- endif %}
+
+##### vCenter Parameters
 
 # < vCenter Datacenter >
 # vCenter datacenter to deploy Nuage components
@@ -113,6 +127,8 @@ vcenter_ovftool: "{{ vcenter_ovftool }}"
 # vcenter_ovftool: /usr/bin/ovftool
 {%- endif %}
 
+########################
+
 # < SSH Public Key >
 # Full path to the public key file to be injected into Nuage components to enable passwordless connectivity for configuration
 #
@@ -158,6 +174,8 @@ branding_zip_file: "{{ branding_zip_file }}"
 # branding_zip_file: 
 {%- endif %}
 
+##### Yum
+
 # < Yum update >
 # Flag to indicate whether to perform a Yum update on VSD during the installation
 #
@@ -176,6 +194,8 @@ yum_proxy: "{{ yum_proxy }}"
 # yum_proxy: NONE
 {%- endif %}
 
+#########
+
 # < Nuage Software Version >
 # Nuage software version being installed. Optional for version comparison to skip deployment of some components that have already been installed.
 #
@@ -184,6 +204,8 @@ nuage_software_version: "{{ nuage_software_version }}"
 {%- else %}
 # nuage_software_version: 
 {%- endif %}
+
+##### PoC Parameters
 
 # < VSD Disk Size >
 # Amount of VSD disk space to allocate, in GB. Valid only for KVM deployments. Note: Changing the default value is not a supported configuration.
@@ -230,6 +252,10 @@ vstat_ram: {{ vstat_ram }}
 # vstat_ram: 16777216
 {%- endif %}
 
+####################
+
+##### VSD Authentication
+
 # < VSD Architect URL >
 # VSD Architect URL. Required for tasks during Upgrade, Health Checks etc
 #
@@ -248,6 +274,10 @@ vsd_auth_enterprise: "{{ vsd_auth_enterprise }}"
 # vsd_auth_enterprise: csp
 {%- endif %}
 
+########################
+
+##### VCIN Authentication
+
 # < VCIN URL >
 # VCIN URL used for API interaction. Required for tasks like VRS-E upgrade (through VCIN)
 #
@@ -265,6 +295,10 @@ vcin_auth_enterprise: "{{ vcin_auth_enterprise }}"
 {%- else %}
 # vcin_auth_enterprise: csp
 {%- endif %}
+
+#########################
+
+##### Libnetwork
 
 # < Libnetwork scope >
 # Scope of libnetworking support; local: connectivity between containers is limited to within the local host; global: connectivity between containers may span across hosts in the cluster
@@ -302,4 +336,6 @@ libnetwork_cluster_store_port: {{ libnetwork_cluster_store_port }}
 {%- else %}
 # libnetwork_cluster_store_port: 8500
 {%- endif %}
+
+################
 

--- a/src/deployment_templates/credentials.j2
+++ b/src/deployment_templates/credentials.j2
@@ -105,6 +105,8 @@ vstat_custom_password: "{{ vstat_custom_password }}"
 # vstat_custom_password: 
 {%- endif %}
 
+##### Custom VSD Passwords
+
 # < VSD cna Password >
 # Custom VSD cna password
 #
@@ -195,6 +197,10 @@ vsd_keyserverstore_password: "{{ vsd_keyserverstore_password }}"
 # vsd_keyserverstore_password: 
 {%- endif %}
 
+##########################
+
+##### AWS Credentials
+
 # < AWS Access key >
 # Access key for AWS
 #
@@ -212,4 +218,6 @@ aws_secret_key: "{{ aws_secret_key }}"
 {%- else %}
 # aws_secret_key: 
 {%- endif %}
+
+#####################
 

--- a/src/deployment_templates/nsgvs.j2
+++ b/src/deployment_templates/nsgvs.j2
@@ -26,6 +26,8 @@
     # vmname: (Hostname)
     {%- endif %}
 
+    ##### Target Server
+
     # < Target Server type >
     # Type of environment into which the NSGv will be instantiated
     # (kvm, vcenter, aws) 
@@ -36,6 +38,10 @@
     # Hostname or IP address of the hypervisor or vCenter server where the NSGv will be instantiated
     #
     target_server: "{{ item.target_server }}"
+
+    ###################
+
+    ##### Bootstrap Parameters
 
     # < Bootstrap Method >
     # In the current MetroAE version, NSGv bootstrapping is not supported.  Bootstrap method for the NSGv. The default is 'none' which means no bootstrap will be performed. 'zfb_metro' creates a boostrap ISO file based on the contents of the file zfb_vars.yml. 'zfb_external' is used when a 3rd-party ISO file is to be used.
@@ -74,6 +80,10 @@
     # nsgv_mac: ""
     {%- endif %}
 
+    ##########################
+
+    ##### vCenter Parameters
+
     # < vCenter Datacenter Name >
     # Name of the vCenter Datacenter on which the NSG VM will be deployed. Defaults to the common vCenter Datacenter Name if not defined here.
     #
@@ -100,6 +110,10 @@
     {%- else %}
     # vcenter_datastore: (global vCenter Datastore Name)
     {%- endif %}
+
+    ########################
+
+    ##### AWS Parameters
 
     # < AWS Region >
     # AWS Region
@@ -146,6 +160,8 @@
     # aws_key_name: ""
     {%- endif %}
 
+    ####################
+
     # < AWS Access ENI >
     # ENI for Access Subnetwork
     #
@@ -172,6 +188,10 @@
     {%- else %}
     # aws_eip_allocid: ""
     {%- endif %}
+
+    ####################
+
+    ##### AWS VPC Parameters
 
     # < AWS Provision VPC CIDR >
     # CIDR for provisioning a VPC for the NSGv on AWS
@@ -208,6 +228,10 @@
     {%- else %}
     # provision_vpc_private_subnet_cidr: 
     {%- endif %}
+
+    ########################
+
+    ##### NSG Zero-Factor Bootstrap Parameters for type zfb_metro
 
     # < NSG License File >
     # Path to the VSD license file on the MetroAE host to associate with the NSG
@@ -379,6 +403,8 @@
     {%- else %}
     # nsg_access_port_vlan_number: 
     {%- endif %}
+
+    ##############################################################
 
 {% endfor %}
 {% else %}

--- a/src/deployment_templates/vcins.j2
+++ b/src/deployment_templates/vcins.j2
@@ -12,6 +12,8 @@
 # VCIN {{ loop.index }}
 #
 -
+    ##### Management Interface
+
     # < Hostname >
     # Hostname of the VCIN instance
     #
@@ -32,6 +34,8 @@
     #
     mgmt_gateway: "{{ item.mgmt_gateway }}"
 
+    ##########################
+
     # < VM name >
     # Name of the Virtual Machine on the Hypervisor
     #
@@ -40,6 +44,8 @@
     {%- else %}
     # vmname: (Hostname)
     {%- endif %}
+
+    ##### Target Server
 
     # < Target Server Type >
     # Type of hypervisor environment where VMs will be instantiated
@@ -52,6 +58,8 @@
     #
     target_server: "{{ item.target_server }}"
 
+    ###################
+
     # < Master VCIN hostname >
     # The FQDN or IP address of the Master VCIN in an Active/Standby deployment. Only used when this VCIN is part of an active/standby configuration. The hostname provided here must match the hostname of another VCIN in the list of VCINs for this deployment.
     #
@@ -60,6 +68,8 @@
     {%- else %}
     # master_vcin: 
     {%- endif %}
+
+    ##### vCenter Parameters
 
     # < vCenter Datacenter Name >
     # Name of the vCenter Datacenter on which the VCIN VM will be deployed. Defaults to the common vCenter Datacenter Name if not defined here.
@@ -87,6 +97,8 @@
     {%- else %}
     # vcenter_datastore: (global vCenter Datastore Name)
     {%- endif %}
+
+    ########################
 
 {% endfor %}
 {% else %}

--- a/src/deployment_templates/vnsutils.j2
+++ b/src/deployment_templates/vnsutils.j2
@@ -12,6 +12,8 @@
 # VNSUtil {{ loop.index }}
 #
 -
+    ##### Management Interface
+
     # < Hostname >
     # Hostname of the Proxy/Util-VM instance
     #
@@ -32,6 +34,8 @@
     #
     mgmt_gateway: "{{ item.mgmt_gateway }}"
 
+    ##########################
+
     # < VM name >
     # Name of the Virtual Machine on the Hypervisor
     #
@@ -40,6 +44,8 @@
     {%- else %}
     # vmname: (Hostname)
     {%- endif %}
+
+    ##### Target Server
 
     # < Target Server Type >
     # Type of hypervisor environment into which the instance will be created
@@ -52,6 +58,8 @@
     #
     target_server: "{{ item.target_server }}"
 
+    ###################
+
     # < Management Bridge interface >
     # Network Bridge used for the management interface of a component or the BOF interface on the VM. This will be a Distributed Virtual PortGroup (DVPG) when deploying on vCenter or a Linux network bridge (ex: br0) when deploying on KVM. This field takes precedence over the value defined in the Commons section
     #
@@ -60,6 +68,8 @@
     {%- else %}
     # mgmt_bridge: (global Bridge interface)
     {%- endif %}
+
+    ##### Data Interface
 
     # < VNSUTIL Data FQDN >
     #
@@ -94,6 +104,10 @@
     # data_subnet: 
     {%- endif %}
 
+    ####################
+
+    ##### NSGv Parameters
+
     # < NSGV IP Address >
     #
     {%- if item.nsgv_ip is defined %}
@@ -117,6 +131,10 @@
     {%- else %}
     # nsgv_hostname: nsgv1.(DNS Domain)
     {%- endif %}
+
+    #####################
+
+    ##### vCenter Parameters
 
     # < vCenter Datacenter Name >
     # Name of the vCenter Datacenter on which the Proxy/Util VM will be deployed. Defaults to the common vCenter Datacenter Name if not defined here.
@@ -144,6 +162,10 @@
     {%- else %}
     # vcenter_datastore: (global vCenter Datastore Name)
     {%- endif %}
+
+    ########################
+
+    ##### AWS Parameters
 
     # < AWS Region >
     # Only applicable for AWS deployments
@@ -198,6 +220,8 @@
     {%- else %}
     # aws_data_eni: ""
     {%- endif %}
+
+    ####################
 
 {% endfor %}
 {% else %}

--- a/src/deployment_templates/vrss.j2
+++ b/src/deployment_templates/vrss.j2
@@ -12,6 +12,8 @@
 # VRS {{ loop.index }}
 #
 -
+    ##### Compute Nodes
+
     # < VRS Hypervisor OS type >
     # Hypervisor type for VRS installation
     # (u16.04, el7) 
@@ -22,6 +24,10 @@
     # Hypervisor Management IP list on which VRS will be installed
     #
     vrs_ip_list: [ {% for i in item.vrs_ip_list | default([]) %}"{{ i }}", {% endfor %}]
+
+    ###################
+
+    ##### Controller Configuration
 
     # < Active Controller IP address >
     # Primary/Active Controller IP address
@@ -36,6 +42,8 @@
     {%- else %}
     # standby_controller_ip: ""
     {%- endif %}
+
+    ##############################
 
     # < DKMS install >
     # Optional DKMS module installation for MPLSoGRE tunnel type

--- a/src/deployment_templates/vscs.j2
+++ b/src/deployment_templates/vscs.j2
@@ -12,6 +12,8 @@
 # VSC {{ loop.index }}
 #
 -
+    ##### Management Network
+
     # < Hostname >
     # Hostname of the VSC instance
     #
@@ -32,6 +34,10 @@
     #
     mgmt_gateway: "{{ item.mgmt_gateway }}"
 
+    ########################
+
+    ##### Control Network
+
     # < Control IP address >
     # The Control/Data IP address of the controller
     #
@@ -41,6 +47,8 @@
     # Control network prefix length
     #
     ctrl_ip_prefix: {{ item.ctrl_ip_prefix }}
+
+    #####################
 
     # < System IP address >
     # Required for BGP pairing with peers
@@ -74,6 +82,8 @@
     # mgmt_static_route_list: [ 0.0.0.0/1, 128.0.0.0/1 ]
     {%- endif %}
 
+    ##### Target Server
+
     # < Target Server type >
     # Type of hypervisor environment into which the instance will be created
     # (kvm, vcenter, heat, aws) 
@@ -84,6 +94,8 @@
     # Hostname or IP address of the hypervisor where VM  will be instantiated. In the case of deployment in a vCenter environment, this will be the FQDN of the vCenter Server
     #
     target_server: "{{ item.target_server }}"
+
+    ###################
 
     # < Management Network Bridge >
     # Network Bridge used for the management interface of a component or the BOF interface on VSC. This will be a Distributed Virtual PortGroup (DVPG) when deploying on vCenter or a Linux network bridge when deploying on KVM. This field can be overridden by defining the management network bridge separately in the component configuration. Defaults to the global setting
@@ -102,6 +114,8 @@
     {%- else %}
     # vsd_fqdn: ""
     {%- endif %}
+
+    ##### vCenter Parameters
 
     # < vCenter Datacenter Name >
     # Name of the vCenter Datacenter on which the VSC VM will be deployed. Defaults to the common vCenter Datacenter Name if not defined here.
@@ -129,6 +143,10 @@
     {%- else %}
     # vcenter_datastore: (global vCenter Datastore Name)
     {%- endif %}
+
+    ########################
+
+    ##### Health Parameters
 
     # < Expected number of BGP neighbors >
     # Used in postdeploy and health workflows as expected values if non-zero
@@ -175,6 +193,10 @@
     # expected_num_gateway_ports: 0
     {%- endif %}
 
+    #######################
+
+    ##### AWS Parameters
+
     # < Private Management IP >
     # Private Management IP Address of VSC Instances on AWS
     #
@@ -210,6 +232,8 @@
     {%- else %}
     # internal_ctrl_ip: ""
     {%- endif %}
+
+    ####################
 
 {% endfor %}
 {% else %}

--- a/src/deployment_templates/vsds.j2
+++ b/src/deployment_templates/vsds.j2
@@ -12,6 +12,8 @@
 # VSD {{ loop.index }}
 #
 -
+    ##### Management Interface
+
     # < Hostname >
     # VSD Hostname
     #
@@ -32,6 +34,8 @@
     #
     mgmt_gateway: "{{ item.mgmt_gateway }}"
 
+    ##########################
+
     # < VM name >
     # Name of the Virtual Machine on the Hypervisor
     #
@@ -50,6 +54,8 @@
     # upgrade_vmname: ""
     {%- endif %}
 
+    ##### Target Server
+
     # < Target Server Type >
     # Type of hypervisor environment into which the instance will be created
     # (kvm, vcenter, heat, aws) 
@@ -61,6 +67,8 @@
     #
     target_server: "{{ item.target_server }}"
 
+    ###################
+
     # < Management Network Bridge >
     # Network Bridge used for the management interface of a component or the BOF interface on VSC. This will be a Distributed Virtual PortGroup (DVPG) when deploying on vCenter or a Linux network bridge when deploying on KVM. This field can be overridden by defining the management network bridge separately in the component configuration. Defaults to the global setting
     #
@@ -69,6 +77,8 @@
     {%- else %}
     # mgmt_bridge: (global Bridge interface)
     {%- endif %}
+
+    ##### vCenter Parameters
 
     # < vCenter Datacenter Name >
     # Name of the vCenter Datacenter on which the VSD VM will be deployed. Defaults to the common vCenter Datacenter Name if not defined here.
@@ -96,6 +106,10 @@
     {%- else %}
     # vcenter_datastore: (global vCenter Datastore Name)
     {%- endif %}
+
+    ########################
+
+    ##### AWS Parameters
 
     # < AWS Region >
     # Only applicable for AWS deployments
@@ -150,6 +164,8 @@
     {%- else %}
     # aws_mgmt_eni: ""
     {%- endif %}
+
+    ####################
 
 {% endfor %}
 {% else %}

--- a/src/deployment_templates/vstats.j2
+++ b/src/deployment_templates/vstats.j2
@@ -12,6 +12,8 @@
 # VSTAT {{ loop.index }}
 #
 -
+    ##### Management Interface
+
     # < Hostname >
     # Management network host name for the VSTAT
     #
@@ -32,6 +34,8 @@
     #
     mgmt_gateway: "{{ item.mgmt_gateway }}"
 
+    ##########################
+
     # < VM name >
     # Name of the Virtual Machine on the Hypervisor
     #
@@ -50,6 +54,8 @@
     # upgrade_vmname: ""
     {%- endif %}
 
+    ##### Target Server
+
     # < Target Server type >
     # Type of hypervisor environment into which the instance will be created
     # (kvm, vcenter, heat, aws) 
@@ -60,6 +66,8 @@
     # Hostname or IP address of the hypervisor where VM  will be instantiated. In the case of deployment in a vCenter environment, this will be the FQDN of the vCenter Server
     #
     target_server: "{{ item.target_server }}"
+
+    ###################
 
     # < Management Network Bridge >
     # Network Bridge used for the management interface of a component or the BOF interface on VSC. This will be a Distributed Virtual PortGroup (DVPG) when deploying on vCenter or a Linux network bridge when deploying on KVM. This field can be overridden by defining the management network bridge separately in the component configuration. Defaults to the global setting
@@ -79,6 +87,8 @@
     # vsd_fqdn: 
     {%- endif %}
 
+    ##### vCenter Parameters
+
     # < vCenter Datacenter Name >
     # Name of the vCenter Datacenter on which the VSTAT VM will be deployed. Defaults to the common vCenter Datacenter Name if not defined here.
     #
@@ -97,6 +107,8 @@
     # vcenter_cluster: (global vCenter Cluster Name)
     {%- endif %}
 
+    ##### vCenter Parameters
+
     # < vCenter Datastore Name >
     # Name of the vCenter Datastore on which the VSTAT VM will be deployed. Defaults to the common vCenter Datastore Name if not defined here.
     #
@@ -105,6 +117,8 @@
     {%- else %}
     # vcenter_datastore: (global vCenter Datastore Name)
     {%- endif %}
+
+    ##### AWS Parameters
 
     # < AWS AMI ID >
     # AMI ID for AWS instance
@@ -150,6 +164,8 @@
     {%- else %}
     # aws_mgmt_eni: ""
     {%- endif %}
+
+    ####################
 
 {% endfor %}
 {% else %}

--- a/src/workflows.yml
+++ b/src/workflows.yml
@@ -52,6 +52,7 @@ schemas:
 workflows:
   - name: Install
     steps:
+      - build
       - install_vsds
       - install_vscs
       - install_vrss
@@ -90,6 +91,7 @@ workflows:
         schemas: ['credentials']
   - name: Upgrade
     steps:
+      - build
       - vsp_preupgrade_health
       - upgrade_vsds
       - upgrade_vscs
@@ -117,6 +119,7 @@ workflows:
         schemas: ['credentials']
   - name: Destroy
     steps:
+      - build
       - vsc_destroy
       - vsd_destroy
       - vsd_sa_upgrade_destroy
@@ -158,6 +161,7 @@ workflows:
         schemas: ['credentials']
   - name: Health
     steps:
+      - build
       - vsd_health
       - vcin_health
       - vstat_health


### PR DESCRIPTION
- Added section headers to deployment examples.  Please look at the real code in generate_example_from_schema.py
- Added build steps to the gui workflows.  See workflows.yml.  With back-end server changes, this allows "--skip-build" to be specified.  Server tests pass: http://135.227.181.74:8080/job/Gui/job/server-INSTALL-KVM-SA/19/