### PR TITLE
Fix the ability to parse vault encrypted variables

### DIFF
--- a/src/library/validate_against_schema.py
+++ b/src/library/validate_against_schema.py
@@ -29,6 +29,10 @@ EXAMPLES = '''
 '''
 
 
+def vault_constructor(loader, node):
+    return node.value
+
+
 def validate_against_schema(path, schema):
     with open(schema, 'r') as file:
         try:
@@ -40,7 +44,8 @@ def validate_against_schema(path, schema):
 
     with open(path, 'r') as file:
         try:
-            parsed_yaml = yaml.safe_load(file.read())
+            yaml.add_constructor(u'!vault', vault_constructor)
+            parsed_yaml = yaml.load(file.read())
         except Exception as e:
             msg = "Could not load yaml file %s: %s" % (path, str(e))
             print msg

--- a/src/library/yaml_checker.py
+++ b/src/library/yaml_checker.py
@@ -35,9 +35,8 @@ def no_duplicates_constructor(loader, node, deep=False):
     return loader.construct_mapping(node, deep)
 
 
-# yaml.add_constructor(
-#     yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
-#     no_duplicates_constructor)
+def vault_constructor(loader, node):
+    return node.value
 
 
 def check_yaml(filepath):
@@ -46,6 +45,7 @@ def check_yaml(filepath):
         yaml.add_constructor(
             yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
             no_duplicates_constructor)
+        yaml.add_constructor(u'!vault', vault_constructor)
         yaml.load(fil)
         module.exit_json(changed=False)
     except yaml.YAMLError as exc:


### PR DESCRIPTION
Python yaml parser crashes if it tries to parse an unregistered tag like "!vault".