### PR TITLE
Fixes to metroae script for passwords

### DIFF
--- a/metroae
+++ b/metroae
@@ -79,7 +79,6 @@ function check_password_needed {
     if [[ -z $METROAE_PASSWORD ]]; then
         if [[ -a $deployment_dir/$ENCRYPTED_DEPLOYMENT_FILE ]]; then
             fail=0
-            echo "$deployment_dir/$ENCRYPTED_DEPLOYMENT_FILE"
             grep $ENCRYPTED_TOKEN "$deployment_dir/$ENCRYPTED_DEPLOYMENT_FILE" > /dev/null || fail=1
             if [[ $fail -ne 0 ]]; then
                 SKIP_PASSWORD=1


### PR DESCRIPTION
- metroae script did not handle passwords for deployments with spaces
- metroae script threw an error if credentials file was completely missing