### PR TITLE
Improve error message for schema validation

### DIFF
--- a/src/library/validate_against_schema.py
+++ b/src/library/validate_against_schema.py
@@ -57,7 +57,11 @@ def validate_against_schema(path, schema):
         validate(parsed_yaml, parsed_schema)
         module.exit_json(changed=False)
     except ValidationError as e:
-        msg = "Invalid data in %s: %s" % (path, e.message)
+
+        field = ""
+        if "title" in e.schema:
+            field = " for " + e.schema["title"]
+        msg = "Invalid data in %s%s: %s" % (path, field, e.message)
         print msg
         module.fail_json(msg=msg)
 


### PR DESCRIPTION
Error is now like the following:

"msg": "Invalid data in /Users/mpiecuch/nuage-metro/deployments/kvm_sa/vsds.yml for Target Server Type: '' is not one of ['kvm', 'vcenter', 'heat', 'aws']"
