### PR TITLE
Update main.yml for vnsutil certificate issue

### DIFF
--- a/roles/vnsutil-postdeploy/tasks/main.yml
+++ b/roles/vnsutil-postdeploy/tasks/main.yml
@@ -17,7 +17,7 @@
       certificate_type: server
       scp_user: "{{ vnsutil_default_username }}"
       scp_location: /opt/proxy/config/keys
-      additional_parameters: -d {{ data_fqdn }}
+      additional_parameters: -d {{ data_fqdn | default(inventory_hostname) }}
      
   - name: Install supervisord and haproxy
     command: "{{ install_cmd }}"


### PR DESCRIPTION
data_fqdn should be used instead of mgmt fqdn while creating certificates for vnsutil
related to #912 