### PR TITLE
Remove utf-8 encoding from encrypt credentials

### DIFF
--- a/encrypt_credentials.py
+++ b/encrypt_credentials.py
@@ -59,7 +59,7 @@ def encrypt_credentials_file(passcode, deployment_name):
 
         gen_example = ExampleFileGenerator(False, True)
         example_lines = gen_example.generate_example_from_schema(
-            'schemas/credentials.json').encode('utf-8')
+            'schemas/credentials.json')
         template = jinja2.Template(example_lines)
         credentials = template.render(credentials=credentials)
         with open(credentials_file, 'w') as file:


### PR DESCRIPTION
Fixes bug found in container testing. Non-ascii encoding

http://135.227.181.74:8080/job/Container_Tests/245/consoleFull

Fixed in 

http://135.227.181.74:8080/job/Container_Tests/251/console