### PR TITLE
Remove upgrade check for ntp sync

### DIFF
--- a/src/roles/vsc-health/tasks/main.yml
+++ b/src/roles/vsc-health/tasks/main.yml
@@ -317,13 +317,11 @@
     until: not ntp_status.stdout[0]|search('none')
     retries: "{{ ntp_sync_retries }}"
     delay: "{{ ntp_sync_delay }}"
-    ignore_errors: "{{ not nuage_upgrade | default(False) }}"
 
   - name: Verify NTP status
     assert:
       that: not ntp_status.stdout[0]|search('none')
       msg: "NTP Status not okay: {{ ntp_status.stdout[0] }}. Quitting."
-    ignore_errors: "{{ not nuage_upgrade | default(False) }}"
 
   - name: Write NTP status to report
     nuage_append: filename="{{ report_path }}" text="{{ inventory_hostname }} NTP Status {{ ntp_status.stdout[0] }}\n"


### PR DESCRIPTION
If NTP sync fails on install, it should error out. Right now we ignore the error. 

Tested with current install and upgrade jobs
http://135.227.181.74:8080/job/INSTALL-KVM-SA/349/
http://135.227.181.74:8080/job/UPGRADE-KVM-SA/153/