### PR TITLE
Lock netmiko version to 2.3.0

### DIFF
--- a/pip_requirements.txt
+++ b/pip_requirements.txt
@@ -4,7 +4,7 @@ ipaddr
 jsonschema
 jmespath
 netaddr==0.7.19
-netmiko
+netmiko==2.3.0
 paramiko==2.4.1
 pexpect
 pyvmomi


### PR DESCRIPTION
http://mvjira.mv.usa.alcatel.com:8080/browse/METROAE-925

Failure building the MetroAE container (need to lock the netmiko library to version 2.3.0):

03:36:58 Collecting netmiko (from -r /source/nuage-metro/pip_requirements.txt (line 7))

03:36:58 Downloading 
https://files.pythonhosted.org/packages/fe/53/d5b6def293c0da913054f2fbfd902dda508a967c96c3a21be0ec5f6544a6/netmiko-2.3.3.tar.gz
(81kB)

03:36:58 Complete output from command python setup.py egg_info:

03:36:58 /usr/lib64/python2.7/distutils/dist.py:267: UserWarning: Unknown distribution option: 'long_description_content_type'

03:36:58 warnings.warn(msg)

03:36:58 error in netmiko setup command: 'install_requires' must be a string or list of strings containing valid project/version requirement specifiers
