### PR TITLE
Lock jsonschema library version to one that supports internal references

### DIFF
--- a/pip_requirements.txt
+++ b/pip_requirements.txt
@@ -1,7 +1,7 @@
 ansible==2.4.0.0
 jinja2==2.8.1
 ipaddr
-jsonschema
+jsonschema==2.6.0
 jmespath
 netaddr==0.7.19
 netmiko==2.3.0


### PR DESCRIPTION
http://mvjira.mv.usa.alcatel.com:8080/browse/METROAE-933

In the latest jsonschema library (3.0.1) internal references are broken:

jsonschema.exceptions.RefResolutionError: <urlopen error unknown url type: urn>

The library has not fixed this issue:

https://github.com/Julian/jsonschema/issues/343

So we will have to lock the library down to a known working version (2.6.0)