### PR TITLE
Fix setup script: "Setting HTTP_PROXY from /etc/yum.conf..../metro-se…

### DIFF
--- a/metro-setup.sh
+++ b/metro-setup.sh
@@ -217,7 +217,7 @@ set_https_proxy() {
   printn "Setting HTTP_PROXY from /etc/yum.conf... "
   # The ^proxy is to skip any commened proxy config line
   grep_out=`grep ^proxy /etc/yum.conf`
-  if [ -z $grep_out ]
+  if [ -z "$grep_out" ]
   then
     echo_skipped
   else


### PR DESCRIPTION
Fix setup script: "Setting HTTP_PROXY from /etc/yum.conf..../metro-setup.sh: line 220: [: too many arguments"