### PR TITLE
Make VSD destroy serial

### DIFF
--- a/src/playbooks/with_build/vsd_destroy.yml
+++ b/src/playbooks/with_build/vsd_destroy.yml
@@ -1,6 +1,7 @@
 ---
 - hosts: vsds
   gather_facts: no
+  serial: 1
   roles:
     - vsd-destroy
   vars:


### PR DESCRIPTION
There seems to be some kind of race condition when destroying KVM VMs.  It fails with an error message saying that the id was not found.  The ID ends up being incorrect.  I am trying setting the VSD destroy to be serial.

http://mvjira.mv.usa.alcatel.com:8080/browse/METROAE-993
