### PR TITLE
Simplifying the retrieval of the UUID based of already present data in previous tasks

### DIFF
--- a/src/roles/vsc-predeploy/tasks/vcenter.yml
+++ b/src/roles/vsc-predeploy/tasks/vcenter.yml
@@ -83,7 +83,7 @@
       {{ ovftool_command }}
       "vi://{{ vcenter.username | urlencode }}:{{ vcenter.password | urlencode }}@{{ vcenter_path }}"
 
-  - name: Finding VM folder (ignoring errors)
+  - name: Finding VM folder 
     connection: local
     vmware_guest_find:
       hostname: "{{ target_server }}"
@@ -92,9 +92,8 @@
       name: "{{ vmname }}"
       validate_certs: no
     register: vsc_vm_folder
-    ignore_errors: on
 
-  - name: Gathering info on VM (ignoring errors)
+  - name: Gathering info on VM 
     connection: local
     vmware_guest_facts:
       hostname: "{{ target_server }}"
@@ -105,28 +104,12 @@
       name: "{{ vmname }}"
       validate_certs: no
     register: vsc_vm_facts
-    ignore_errors: on
-    when: vsc_vm_folder is succeeded
 
   - debug: var=vsc_vm_facts verbosity=1
 
-  - name: Get Facts of VM
-    vmware_vm_facts:
-      hostname: "{{ target_server }}"
-      username: "{{ vcenter.username }}"
-      password: "{{ vcenter.password }}"
-      validate_certs: no
-    delegate_to: localhost
-    register: vm_list
-
-  - name: Verify VM exists on Host
-    assert:
-      that: "vm_name in vm_list.virtual_machines"
-      msg: "Desired VM does not exist"
-
   - name: Set VM UUID
     set_fact:
-      uuid: "{{ vm_list.virtual_machines[vm_name]['uuid'] }}"
+      uuid: "{{ vsc_vm_facts.instance.hw_product_uuid }}"
 
   - debug: var=uuid
 

--- a/src/roles/vsd-predeploy/tasks/vcenter.yml
+++ b/src/roles/vsd-predeploy/tasks/vcenter.yml
@@ -65,23 +65,9 @@
 
   - debug: var=vm_facts verbosity=1
 
-  - name: Get Facts of VM
-    vmware_vm_facts:
-      hostname: "{{ target_server }}"
-      username: "{{ vcenter.username }}"
-      password: "{{ vcenter.password }}"
-      validate_certs: no
-    delegate_to: localhost
-    register: vm_list
-
-  - name: Verify that VM exists on Host
-    assert:
-      that: "vm_name in vm_list.virtual_machines"
-      msg: "Desired VM does not exist"
-
   - name: Set VM UUID
     set_fact:
-      uuid: "{{ vm_list.virtual_machines[vm_name]['uuid'] }}"
+      uuid: "{{ vm_facts.instance.hw_product_uuid }}"
 
   - debug: var=uuid
 

--- a/src/roles/vstat-predeploy/tasks/vcenter.yml
+++ b/src/roles/vstat-predeploy/tasks/vcenter.yml
@@ -61,23 +61,9 @@
 
   - debug: var=vm_facts verbosity=1
 
-  - name: Get Facts of VM
-    vmware_vm_facts:
-      hostname: "{{ target_server }}"
-      username: "{{ vcenter.username }}"
-      password: "{{ vcenter.password }}"
-      validate_certs: no
-    delegate_to: localhost
-    register: vm_list
-
-  - name: Verify VM exists on Host
-    assert:
-      that: "vm_name in vm_list.virtual_machines"
-      msg: "Desired VM does not exist"
-
   - name: Set VM UUID
     set_fact:
-      uuid: "{{ vm_list.virtual_machines[vm_name]['uuid'] }}"
+      uuid: "{{ vm_facts.instance.hw_product_uuid }}"
 
   - debug: var=uuid
 


### PR DESCRIPTION
VSD/VSTAT: The `vmware_guest_tools_wait` module already returns the facts for the VM, including the UUID, so there's no need to fetch all VMs in the environment and go through the list (because in environments with 1000's of VMs, that's going to be very costly). 

VSC: This can be simplified as well, and especially optimized.

One of the reasons i'm doing this: in Ansible 2.8, for the `vmware_vm_facts` module, it was apparently decided to no longer return a dict of dicts, but to return a list of dicts (i'm not a big fan of that decision, but i understand why that decision was made). So now it is a lot harder to find the VM that you are actually looking from that list (have to go looping and stuff, it's dirty). (the reason that decision was made is because the `vmware_vm_facts` module is not meant to be used to find a single VM, it's meant for inventory management)
