### PR TITLE
V6 vsd health

### DIFF
--- a/src/roles/vsd-health/tasks/main.yml
+++ b/src/roles/vsd-health/tasks/main.yml
@@ -249,6 +249,11 @@
 
   when: check_vsd_license | default(True)
 
+- name: Get the JAVA_HOME
+  shell: echo $JAVA_HOME
+  register: java_home
+  remote_user: "{{ vsd_custom_username | default(vsd_default_username) }}"
+
 - block:
 
   - name: Verify keystore pass is set
@@ -263,19 +268,9 @@
     shell: "keytool -keystore /opt/vsd/jboss/standalone/configuration/keyserver.jks -storepass {{ keyServerStorePwd }} -list"
     when: keyServerStorePwd is defined
 
-  - name: Show version of the vsd
-    shell: "echo $VSD_VERSION"
-    register: vsd_version
-
-  - debug: var=vsd_version.stdout
-
-  - name: Verify jrestore pass is set for version greater than 6.0.1
-    shell: "keytool -keystore /etc/pki/ca-trust/extracted/java/cacerts -alias vspca -storepass {{ jreStorePwd }} -list"
-    when: jreStorePwd is defined and vsd_version.stdout is version('6.0.1', '>=')
-
-  - name: Verify jrestore pass is set for version less than 6.0.1
-    shell: "keytool -keystore /usr/java/latest/lib/security/cacerts -alias vspca -storepass {{ jreStorePwd }} -list"
-    when: jreStorePwd is defined and vsd_version.stdout is version('6.0.1', '<')
+  - name: Verify jrestore pass is set for version
+    shell: "keytool -keystore {{ java_home.stdout }}/lib/security/cacerts -alias vspca -storepass {{ jreStorePwd }} -list"
+    when: jreStorePwd is defined
 
   - name: Verify cnauser pass is set
     command: "mysql -ucnauser -p{{ cnaPwd }} -e 'select 1'"


### PR DESCRIPTION
* Fixed an issue where the `cacerts` could not be found via replacing absolute path with JSON_HOME
* The problem for this is JSON_HOME is not available in customize user in some version of the vsd. We need to get the path with default user.

[Test for 6.0.1](http://135.227.181.74:8080/job/gcp/job/GCP-INSTALL-KVM-SA/475/)