### PR TITLE
Support for ipv6 API request 

### DIFF
--- a/src/roles/vsd-health/tasks/main.yml
+++ b/src/roles/vsd-health/tasks/main.yml
@@ -160,9 +160,14 @@
 
 - block:
 
+  - name: Set the URL for the VSD
+    set_fact:
+      vsd_url_address: >-
+        {% if enable_ipv6|default(False) %}[{{mgmt_ip}}]{% else %}{{mgmt_ip}}{% endif %}
+      
   - name: Get the health status of VSD (ignoring errors)
     uri:
-      url: https://{{ mgmt_ip }}:8443/nuage/health?proxyRequest=false
+      url: https://{{ vsd_url_address }}:8443/nuage/health?proxyRequest=false
       method: GET
       user: "{{ vsd_auth.username }}"
       password: "{{ vsd_auth.password }}"


### PR DESCRIPTION
URI module doesn't directly recognize ipv6 address and results in error, we need to pass the ipv6 address in a [ipv6] format for it to recognize and parse.