### PR TITLE
Fix vsd-node-info check for XMPP

### DIFF
--- a/src/roles/common/tasks/vsd-node-info.yml
+++ b/src/roles/common/tasks/vsd-node-info.yml
@@ -1,5 +1,5 @@
-- name: Resolve "{{ vsd_hostname }}"  to ip addr
-  shell: "getent hosts {{ vsd_hostname }} | awk '{print $1}'"
+- name: Resolve "{{ groups['primary_vsds'][0] | default(vsd_hostname) }}" to ip addr
+  shell: "getent hosts {{ groups['primary_vsds'][0] | default(vsd_hostname) }} | awk '{print $1}'"
   register: ip_addr
   delegate_to: localhost
   become: no


### PR DESCRIPTION
Check for the primary node ip rather than xmpp ip address, XMPP can return vms from the primary as well as secondary. Keep the default as backup if no VSD is in deployments