### PR TITLE
Sdwan portal proxy check fix

### DIFF
--- a/src/roles/sdwan-portal-deploy/tasks/docker.yml
+++ b/src/roles/sdwan-portal-deploy/tasks/docker.yml
@@ -60,15 +60,15 @@
     name: docker
   when: not yum_proxy | match('NONE')
 
-- name: Download Docker-Compose using a yum proxy
+- name: Download Docker-Compose without using a yum proxy
   get_url:
     url: "https://github.com/docker/compose/releases/download/1.23.2/docker-compose-Linux-x86_64"
     dest: /usr/bin/docker-compose
     mode: 0755
-    use_proxy: yes
-  when: yum_proxy | match('NONE')
+    use_proxy: no
+  when: yum_proxy is match('NONE')
 
-- name: Download Docker-Compose without using a yum proxy
+- name: Download Docker-Compose with using a yum proxy
   get_url:
     url: "https://github.com/docker/compose/releases/download/1.23.2/docker-compose-Linux-x86_64"
     dest: /usr/bin/docker-compose
@@ -77,4 +77,4 @@
   environment:
     http_proxy: "{{ yum_proxy | default('') }}"
     https_proxy: "{{ yum_proxy | default('') }}"
-  when: not yum_proxy | match('NONE')
+  when: yum_proxy is not match('NONE')


### PR DESCRIPTION
added a second "Download Docker-Compose" block for yum_proxy not defined cases.
"Configure yum proxy"  block is fixed so now it can decide if yum_proxy is NONE or not properly.

Both of the block changes have been tested, but would be nice to have a second eye on those before merging into official branches