### PR TITLE
(Do not merge) Changes to deploy on openstack (in dhcp network)

### DIFF
--- a/src/roles/common/templates/group_vars.all.j2
+++ b/src/roles/common/templates/group_vars.all.j2
@@ -226,6 +226,10 @@ openstack_auth:
   password: {{ encrypted.openstack_password | indent(8, False) }}
   project_name: {{ openstack_project_name }}
   auth_url: {{ openstack_auth_url }}
+# Our openstack needs some extra auth vars
+# not sure if both are needed or if user_domain_name is sufficient
+  project_id: <id>
+  user_domain_name: <domain>
 {% endif %}
 
 {% set zfb_nsg_list = nsgvs | selectattr("bootstrap_method", "equalto", "zfb_metro") | list %}

--- a/src/roles/vsc-deploy/templates/config.cfg.j2
+++ b/src/roles/vsc-deploy/templates/config.cfg.j2
@@ -23,6 +23,10 @@ echo "System Configuration"
             tls-profile "vsc-tls-profile" create
                 shutdown
             exit
+# For openstack system ip is not used, so ntp should use control
+            source-address
+                application ntp "control"
+            exit
         exit
     exit
 #--------------------------------------------------

--- a/src/roles/vsc-predeploy/templates/openstack.j2
+++ b/src/roles/vsc-predeploy/templates/openstack.j2
@@ -19,45 +19,17 @@ parameters:
   control_ip:
     type: string
 resources:
-  mgmt_port:
-    type: OS::Neutron::Port
-    properties:
-      network_id: {get_param: vsc_management_network}
-      fixed_ips: [{"subnet": {get_param: vsc_management_subnet}, "ip_address": {get_param: mgmt_ip}}]
-{% if openstack_mgmt_port_name is defined %}
-      name: {{ openstack_mgmt_port_name }}
-{% endif %}
-{% if openstack_mgmt_port_security_groups is defined %}
-      security_groups: ["{{ openstack_mgmt_port_security_groups | join('", "') }}"]
-{% endif %}
-
-  control_port:
-    type: OS::Neutron::Port
-    properties:
-      network_id: {get_param: vsc_control_network}
-      fixed_ips: [{"subnet": {get_param: vsc_control_subnet}, "ip_address": {get_param: control_ip}}]
-{% if openstack_control_port_name is defined %}
-      name: {{ openstack_control_port_name }}
-{% endif %}
-{% if openstack_control_port_security_groups is defined %}
-      security_groups: ["{{ openstack_control_port_security_groups | join('", "') }}"]
-{% endif %}
 
   mycompute:
     type: OS::Nova::Server
     properties:
-{% if openstack_availability_zone is defined %}
-      availability_zone: {{ openstack_availability_zone }}
-{% endif %}
+      availability_zone: {get_param: availability_zone}
       name: {get_param: vm_name}
       flavor: {get_param: vsc_flavor }
       image: {get_param: vsc_image}
-{% if openstack_availability_zone is defined %}
-      availability_zone: {{ openstack_availability_zone }}
-{% endif %}
       networks:
-        - port: {get_resource: mgmt_port}
-        - port: {get_resource: control_port}
+        - port: {{ openstack_mgmt_port_name }}
+        - port: {{ openstack_control_port_name }}
 
 outputs:
   vsc_mgmt_ip:

--- a/src/roles/vsd-deploy/tasks/main.yml
+++ b/src/roles/vsd-deploy/tasks/main.yml
@@ -280,6 +280,21 @@
 
   - block:
 
+    # problem, vsd get dns server by dhcp, the one defined in the metro deployment
+    #   gets added as last. => in a timeout during vsd dns check,
+    # this makes sure only the on configure has to be in resolv.conf
+    - name: fix resolv.conf
+      become: yes
+      when: inventory_hostname == first_cluster_node_to_install or inventory_hostname == second_cluster_node_to_install or inventory_hostname == third_cluster_node_to_install
+      copy:
+        content: |
+          nameserver 10.40.1.100
+        dest: "/etc/resolv.conf"
+        force: yes
+        group: root
+        owner: root
+        mode: 644
+
     - name: Install VSD software on the first cluster node (Can take 20 minutes)
       command: "/opt/vsd/vsd-install.sh -t 1 -a {{ first_cluster_node_to_install }} -b {{ second_cluster_node_to_install }} -c {{third_cluster_node_to_install}} -x {{vsd_fqdn}} -y {{ (enable_ipv6 | default(False) == True) | ternary('-6', '') }}"
       when: inventory_hostname == first_cluster_node_to_install

--- a/src/roles/vsd-predeploy/templates/openstack.j2
+++ b/src/roles/vsd-predeploy/templates/openstack.j2
@@ -16,28 +16,15 @@ parameters:
     type: string
 
 resources:
-  mgmt_port:
-    type: OS::Neutron::Port
-    properties:
-      network_id: {get_param: vsd_network}
-      fixed_ips: [{"subnet": {get_param: vsd_subnet}, "ip_address": {get_param: mgmt_ip}}]
-{% if openstack_port_name is defined %}
-      name: {{ openstack_port_name }}
-{% endif %}
-{% if openstack_port_security_groups is defined %}
-      security_groups: ["{{ openstack_port_security_groups | join('", "') }}"]
-{% endif %}
+
   mycompute:
     type: OS::Nova::Server
     properties:
       name: {get_param: vm_name}
       flavor: {get_param: vsd_flavor}
       image: {get_param: vsd_image}
-{% if openstack_availability_zone is defined %}
-      availability_zone: {{ openstack_availability_zone }}
-{% endif %}
       networks:
-        - port: {get_resource: mgmt_port}
+        - port: {{ openstack_port_name }}
       user_data_format: RAW
 {% if openstack_availability_zone is defined %}
       availability_zone: "{{ openstack_availability_zone }}"
@@ -55,3 +42,4 @@ outputs:
   server_ip:
     description: mgmt ip assigned to vsd
     value: { get_attr: [mycompute, networks, {get_param: vsd_network}, 0]}
+


### PR DESCRIPTION
Hi @bacastelli 

Some of the changes i made to the code, to allow for deployments on our specific openstack cluster.
These changes should not be merged (for obvious reasons).
I am not sure if these problems/features will be used by customers. So it might not be worth the effort to create a proper fix.

One more problem i have, which i have not fixed in metro: when vsc is deployed in a dhcp managed subnet, it receives the dns-domain and nameservers, however i have configured a different one in metro deployment, that one is not added as primary or secondary dns.

