### PR TITLE
Revert "Jenkins fixes"

### DIFF
--- a/schemas/nsgv_access_ports.json
+++ b/schemas/nsgv_access_ports.json
@@ -46,7 +46,8 @@
               "description": "Network bridge used for the access network when installing an NSGv. This will be a Distributed Virtual PortGroup (DVPG) when deploying on vCenter or a Linux network bridge",
               "default": 0,
               "propertyOrder": 50,
-              "sectionEnd": "Access ports"
+              "sectionEnd": "Access ports",
+
           }
         },
         "required": ["name", "vlan_range", "bridge"]

--- a/src/playbooks/with_build/vsd_upgrade_complete.yml
+++ b/src/playbooks/with_build/vsd_upgrade_complete.yml
@@ -38,12 +38,3 @@
       include_role:
         name: vsd-deploy
         tasks_from: vsd_security_hardening.yml
-
-    - name: Renew VSD certificates
-      include_role:
-        name: common
-        tasks_from: renew-vsd-certificates.yml
-      when:
-        - not deploy_vcin | default(false)
-        - not inplace_upgrade | default(false)
-      run_once: True

--- a/src/roles/common/tasks/renew-vsd-certificates.yml
+++ b/src/roles/common/tasks/renew-vsd-certificates.yml
@@ -54,19 +54,11 @@
     - name: Renew primary VSD cert
       command: /opt/vsd/bin/vsd-renew-certs.sh
       delegate_to: "{{ item }}"
-      remote_user: "{{ hostvars[item].vsd_custom_username | default(vsd_default_username) }}"
-      become: "{{ 'no' if hostvars[item].vsd_custom_username | default(vsd_default_username) == 'root' else 'yes' }}"
-      vars:
-        ansible_become_pass: "{{ hostvars[item].vsd_custom_password | default(vsd_default_password) }}"
       with_items: "{{ groups['vsd_ha_node1'][0] }}"
 
     - name: Renew other 2 VSD certs
       command: /opt/vsd/bin/vsd-renew-certs.sh -1 {{ hostvars[groups['primary_vsds'][0]]['hostname'] }}
       delegate_to: "{{ item }}"
-      remote_user: "{{ hostvars[item].vsd_custom_username | default(vsd_default_username) }}"
-      become: "{{ 'no' if hostvars[item].vsd_custom_username | default(vsd_default_username) == 'root' else 'yes' }}"
-      vars:
-        ansible_become_pass: "{{ hostvars[item].vsd_custom_password | default(vsd_default_password) }}"
       with_items:
         - "{{ groups['vsd_ha_node2'][0] }}"
         - "{{ groups['vsd_ha_node3'][0] }}"
@@ -76,20 +68,12 @@
       register: ejmode
       delegate_to: "{{ item }}"
       delegate_facts: True
-      remote_user: "{{ hostvars[item].vsd_custom_username | default(vsd_default_username) }}"
-      become: "{{ 'no' if hostvars[item].vsd_custom_username | default(vsd_default_username) == 'root' else 'yes' }}"
-      vars:
-        ansible_become_pass: "{{ hostvars[item].vsd_custom_password | default(vsd_default_password) }}"
       with_items: "{{ groups['primary_vsds'] }}"
 
     - name: Restart ejabberd
       command: monit restart ejabberd
       when: ejmode.results[0].stdout is search('allow')
       delegate_to: "{{ item }}"
-      remote_user: "{{ hostvars[item].vsd_custom_username | default(vsd_default_username) }}"
-      become: "{{ 'no' if hostvars[item].vsd_custom_username | default(vsd_default_username) == 'root' else 'yes' }}"
-      vars:
-        ansible_become_pass: "{{ hostvars[item].vsd_custom_password | default(vsd_default_password) }}"
       with_items: "{{ groups['primary_vsds'] }}"
 
     - name: wait for ejabberd to come up
@@ -98,19 +82,11 @@
         timeout_seconds: 600
         test_interval_seconds: 30
       delegate_to: "{{ item }}"
-      remote_user: "{{ hostvars[item].vsd_custom_username | default(vsd_default_username) }}"
-      become: "{{ 'no' if hostvars[item].vsd_custom_username | default(vsd_default_username) == 'root' else 'yes' }}"
-      vars:
-        ansible_become_pass: "{{ hostvars[item].vsd_custom_password | default(vsd_default_password) }}"
       with_items: "{{ groups['primary_vsds'] }}"
 
     - name: Stop VSD core service
       shell: monit stop -g vsd-core
       delegate_to: "{{ item }}"
-      remote_user: "{{ hostvars[item].vsd_custom_username | default(vsd_default_username) }}"
-      become: "{{ 'no' if hostvars[item].vsd_custom_username | default(vsd_default_username) == 'root' else 'yes' }}"
-      vars:
-        ansible_become_pass: "{{ hostvars[item].vsd_custom_password | default(vsd_default_password) }}"
       with_items: "{{ groups['primary_vsds'] }}"
 
     - name: Pause for processes to exit
@@ -120,27 +96,17 @@
     - name: Restart the VSD core service
       shell: monit start -g vsd-core
       delegate_to: "{{ item }}"
-      remote_user: "{{ hostvars[item].vsd_custom_username | default(vsd_default_username) }}"
-      become: "{{ 'no' if hostvars[item].vsd_custom_username | default(vsd_default_username) == 'root' else 'yes' }}"
-      vars:
-        ansible_become_pass: "{{ hostvars[item].vsd_custom_password | default(vsd_default_password) }}"
       with_items: "{{ groups['primary_vsds'] }}"
 
-    - block:
+    - name: Get monit summary for all process on VSD
+      vsd_monit:
+        group: all
+      register: vsd_process_list
+      delegate_to: "{{ groups['vsd_ha_node1'][0] }}"
 
-      - name: Get monit summary for all process on VSD
-        vsd_monit:
-          group: all
-        register: vsd_process_list
-
-      - name: Restart stats if enabled
-        shell: monit restart -g vsd-stats
-        when: "'stats-collector' in vsd_process_list['state'].keys()"
-
-      remote_user: "{{ hostvars[groups['vsd_ha_node1'][0]].vsd_custom_username | default(vsd_default_username) }}"
-      become: "{{ 'no' if hostvars[groups['vsd_ha_node1'][0]].vsd_custom_username | default(vsd_default_username) == 'root' else 'yes' }}"
-      vars:
-        ansible_become_pass: "{{ hostvars[groups['vsd_ha_node1'][0]].vsd_custom_password | default(vsd_default_password) }}"
+    - name: Restart stats if enabled
+      shell: monit restart -g vsd-stats
+      when: "'stats-collector' in vsd_process_list['state'].keys()"
       delegate_to: "{{ groups['vsd_ha_node1'][0] }}"
 
     when: vsd_sa_or_ha is match ('ha')
@@ -150,31 +116,22 @@
     - name: Renew standby VSD certs
       command: /opt/vsd/bin/vsd-renew-certs.sh -1 {{ hostvars[groups['primary_vsds'][0]]['hostname'] }}
       delegate_to: "{{ item }}"
-      remote_user: "{{ hostvars[item].vsd_custom_username | default(vsd_default_username) }}"
-      become: "{{ 'no' if hostvars[item].vsd_custom_username | default(vsd_default_username) == 'root' else 'yes' }}"
-      vars:
-        ansible_become_pass: "{{ hostvars[item].vsd_custom_password | default(vsd_default_password) }}"
-      with_items: "{{ groups['standby_vsds'] }}"
+      with_items:
+        - "{{ groups['vsd_standby_node1'][0] }}"
+        - "{{ groups['vsd_standby_node2'][0] }}"
+        - "{{ groups['vsd_standby_node3'][0] }}"
 
     - name: Verify if VSD TLS mode is set to allow
       command: /opt/vsd/bin/ejmode status
       register: ejmode
       delegate_to: "{{ item }}"
       delegate_facts: True
-      remote_user: "{{ hostvars[item].vsd_custom_username | default(vsd_default_username) }}"
-      become: "{{ 'no' if hostvars[item].vsd_custom_username | default(vsd_default_username) == 'root' else 'yes' }}"
-      vars:
-        ansible_become_pass: "{{ hostvars[item].vsd_custom_password | default(vsd_default_password) }}"
       with_items: "{{ groups['standby_vsds'] }}"
 
     - name: Restart ejabberd
       command: monit restart ejabberd
       when: ejmode.results[0].stdout is search('allow')
       delegate_to: "{{ item }}"
-      remote_user: "{{ hostvars[item].vsd_custom_username | default(vsd_default_username) }}"
-      become: "{{ 'no' if hostvars[item].vsd_custom_username | default(vsd_default_username) == 'root' else 'yes' }}"
-      vars:
-        ansible_become_pass: "{{ hostvars[item].vsd_custom_password | default(vsd_default_password) }}"
       with_items: "{{ groups['standby_vsds'] }}"
 
     - name: wait for ejabberd to come up
@@ -183,10 +140,6 @@
         timeout_seconds: 600
         test_interval_seconds: 30
       delegate_to: "{{ item }}"
-      remote_user: "{{ hostvars[item].vsd_custom_username | default(vsd_default_username) }}"
-      become: "{{ 'no' if hostvars[item].vsd_custom_username | default(vsd_default_username) == 'root' else 'yes' }}"
-      vars:
-        ansible_become_pass: "{{ hostvars[item].vsd_custom_password | default(vsd_default_password) }}"
       with_items: "{{ groups['standby_vsds'] }}"
 
     when: vsd_standby_cluster | default(False)

--- a/src/roles/vsd-upgrade-complete/tasks/main.yml
+++ b/src/roles/vsd-upgrade-complete/tasks/main.yml
@@ -87,3 +87,12 @@
     when: not inplace_upgrade | default(false)
 
   remote_user: "{{ vsd_default_username }}"
+
+- name: Renew VSD certificates
+  include_role:
+    name: common
+    tasks_from: renew-vsd-certificates.yml
+  when:
+    - not deploy_vcin | default(false)
+    - not inplace_upgrade | default(false)
+  run_once: True


### PR DESCRIPTION
Reverts nuagenetworks/nuage-metro#1417

The vsd-renew-certificate script on the VSD does not support hardened VSDs.  This will never work in HA deployments.  Need to revert and then add error message for this case.