### PR TITLE
Force no_log to true for all known_hosts calls

### DIFF
--- a/src/playbooks/with_build/vsd_standby_deploy.yml
+++ b/src/playbooks/with_build/vsd_standby_deploy.yml
@@ -54,7 +54,7 @@
         name: "{{ inventory_hostname }}"
         state: absent
       delegate_to: localhost
-      no_log: "{{ lookup('env', 'METROAE_NO_LOG') or 'true' }}"
+      no_log: True
       ignore_errors: True
 
     - name: Wait for VSD ssh to be ready

--- a/src/roles/dns-deploy/tasks/main.yml
+++ b/src/roles/dns-deploy/tasks/main.yml
@@ -3,7 +3,7 @@
     name: "{{ mgmt_ip }}"
     state: absent
   delegate_to: localhost
-  no_log: "{{ lookup('env', 'METROAE_NO_LOG') or 'true' }}"
+  no_log: True
   ignore_errors: True
 
 - name: Wait for DNS Utility VM ssh to be ready

--- a/src/roles/nuh-deploy/tasks/main.yml
+++ b/src/roles/nuh-deploy/tasks/main.yml
@@ -4,7 +4,7 @@
     name: "{{ hostname }}"
     state: absent
   delegate_to: localhost
-  no_log: "{{ lookup('env', 'METROAE_NO_LOG') or 'true' }}"
+  no_log: True
   ignore_errors: True
 
 - name: Wait for NUH ssh to be ready

--- a/src/roles/vcin-health/tasks/main.yml
+++ b/src/roles/vcin-health/tasks/main.yml
@@ -3,7 +3,7 @@
     name: "{{ mgmt_ip }}"
     state: absent
   delegate_to: localhost
-  no_log: "{{ lookup('env', 'METROAE_NO_LOG') or 'true' }}"
+  no_log: True
   ignore_errors: True
 
 - import_tasks: report_header.yml

--- a/src/roles/vnsutil-deploy/tasks/main.yml
+++ b/src/roles/vnsutil-deploy/tasks/main.yml
@@ -3,7 +3,7 @@
     name: "{{ mgmt_ip }}"
     state: absent
   delegate_to: localhost
-  no_log: "{{ lookup('env', 'METROAE_NO_LOG') or 'true' }}"
+  no_log: True
   ignore_errors: True
 
 - name: Wait for VNS Utility VM ssh to be ready

--- a/src/roles/vnsutil-postdeploy/tasks/main.yml
+++ b/src/roles/vnsutil-postdeploy/tasks/main.yml
@@ -3,7 +3,7 @@
     name: "{{ mgmt_ip }}"
     state: absent
   delegate_to: localhost
-  no_log: "{{ lookup('env', 'METROAE_NO_LOG') or 'true' }}"
+  no_log: True
   ignore_errors: True
 
 - name: Wait for VNS Utility VM ssh to be ready

--- a/src/roles/vrs-postdeploy/tasks/check_vsc_registration.yml
+++ b/src/roles/vrs-postdeploy/tasks/check_vsc_registration.yml
@@ -15,7 +15,7 @@
       name: "{{ vsc_creds[0].host }}"
       state: absent
     delegate_to: localhost
-    no_log: "{{ lookup('env', 'METROAE_NO_LOG') or 'true' }}"
+    no_log: True
     ignore_errors: True
 
   - name: Set sed-expression variable
@@ -77,7 +77,7 @@
     when: vsc_version.stdout is version('6.0.1', '<')
 
   - block:
-    
+
     - name: Get output of 'show vswitch-controller information' on VSC ({{ controller_addr }}) for version greater than 6.0.1
       sros_command:
         commands:
@@ -85,7 +85,7 @@
         provider: "{{ vsc_creds[0] }}"
       delegate_to: localhost
       register: vsc_vsw_info
-    
+
     - name: Set fact for vswitch_controller_info
       set_fact:
         vswitch_controller_info: "{{ vsc_vsw_info.stdout[0] }}"

--- a/src/roles/vrs-predeploy/tasks/main.yml
+++ b/src/roles/vrs-predeploy/tasks/main.yml
@@ -5,7 +5,7 @@
       name: "{{ inventory_hostname }}"
       state: absent
     delegate_to: localhost
-    no_log: "{{ lookup('env', 'METROAE_NO_LOG') or 'true' }}"
+    no_log: True
     ignore_errors: True
 
   - name: Wait for Compute Node VM ssh to be ready

--- a/src/roles/vsc-backup/tasks/main.yml
+++ b/src/roles/vsc-backup/tasks/main.yml
@@ -7,7 +7,7 @@
     name: "{{ mgmt_ip }}"
     state: absent
   delegate_to: localhost
-  no_log: "{{ lookup('env', 'METROAE_NO_LOG') or 'true' }}"
+  no_log: True
   ignore_errors: True
 
 - name: Wait for VSC ssh to be ready

--- a/src/roles/vsc-deploy/tasks/main.yml
+++ b/src/roles/vsc-deploy/tasks/main.yml
@@ -3,7 +3,7 @@
     name: "{{ mgmt_ip }}"
     state: absent
   delegate_to: localhost
-  no_log: "{{ lookup('env', 'METROAE_NO_LOG') or 'true' }}"
+  no_log: True
   ignore_errors: True
 
 - name: Create empty VPRN object

--- a/src/roles/vsc-health/tasks/main.yml
+++ b/src/roles/vsc-health/tasks/main.yml
@@ -3,7 +3,7 @@
     name: "{{ mgmt_ip }}"
     state: absent
   delegate_to: localhost
-  no_log: "{{ lookup('env', 'METROAE_NO_LOG') or 'true' }}"
+  no_log: True
   ignore_errors: True
 
 - import_tasks: report_header.yml
@@ -27,7 +27,7 @@
     known_hosts:
       name: "{{ mgmt_ip }}"
       state: absent
-    no_log: "{{ lookup('env', 'METROAE_NO_LOG') or 'true' }}"
+    no_log: True
     ignore_errors: True
 
   # Without this, the run creates a false positive as it finds the files

--- a/src/roles/vsc-postdeploy/tasks/main.yml
+++ b/src/roles/vsc-postdeploy/tasks/main.yml
@@ -3,7 +3,7 @@
     name: "{{ mgmt_ip }}"
     state: absent
   delegate_to: localhost
-  no_log: "{{ lookup('env', 'METROAE_NO_LOG') or 'true' }}"
+  no_log: True
   ignore_errors: True
 
 - name: Check VSC Health after deployment

--- a/src/roles/vsc-upgrade-deploy/tasks/main.yml
+++ b/src/roles/vsc-upgrade-deploy/tasks/main.yml
@@ -3,7 +3,7 @@
     name: "{{ mgmt_ip }}"
     state: absent
   delegate_to: localhost
-  no_log: "{{ lookup('env', 'METROAE_NO_LOG') or 'true' }}"
+  no_log: True
   ignore_errors: True
 
 - name: Wait for VSC ssh to be ready

--- a/src/roles/vsc-upgrade-postdeploy/tasks/main.yml
+++ b/src/roles/vsc-upgrade-postdeploy/tasks/main.yml
@@ -4,7 +4,7 @@
     name: "{{ mgmt_ip }}"
     state: absent
   delegate_to: localhost
-  no_log: "{{ lookup('env', 'METROAE_NO_LOG') or 'true' }}"
+  no_log: True
   ignore_errors: True
 
 - name: Wait for VSC ssh to be ready

--- a/src/roles/vsd-deploy/tasks/main.yml
+++ b/src/roles/vsd-deploy/tasks/main.yml
@@ -4,7 +4,7 @@
     name: "{{ hostname }}"
     state: absent
   delegate_to: localhost
-  no_log: "{{ lookup('env', 'METROAE_NO_LOG') or 'true' }}"
+  no_log: True
   ignore_errors: True
 
 - name: Wait for VSD ssh to be ready

--- a/src/roles/vsd-deploy/tasks/vsd_security_hardening.yml
+++ b/src/roles/vsd-deploy/tasks/vsd_security_hardening.yml
@@ -3,7 +3,7 @@
     name: "{{ mgmt_ip }}"
     state: absent
   delegate_to: localhost
-  no_log: "{{ lookup('env', 'METROAE_NO_LOG') or 'true' }}"
+  no_log: True
   ignore_errors: True
 
 - name: Clean known_hosts of VSDs (ignoring errors)
@@ -11,7 +11,7 @@
     name: "{{ inventory_hostname }}"
     state: absent
   delegate_to: localhost
-  no_log: "{{ lookup('env', 'METROAE_NO_LOG') or 'true' }}"
+  no_log: True
   ignore_errors: True
 
 - name: Check if custom user already exists and is connected via ssh

--- a/src/roles/vsd-health/tasks/main.yml
+++ b/src/roles/vsd-health/tasks/main.yml
@@ -3,7 +3,7 @@
     name: "{{ mgmt_ip }}"
     state: absent
   delegate_to: localhost
-  no_log: "{{ lookup('env', 'METROAE_NO_LOG') or 'true' }}"
+  no_log: True
   ignore_errors: True
 
 - name: Wait for VM to be ready
@@ -19,7 +19,7 @@
     name: "{{ mgmt_ip }}"
     state: absent
   delegate_to: localhost
-  no_log: "{{ lookup('env', 'METROAE_NO_LOG') or 'true' }}"
+  no_log: True
   ignore_errors: True
 
 - import_tasks: report_header.yml

--- a/src/roles/vsd-postdeploy/tasks/main.yml
+++ b/src/roles/vsd-postdeploy/tasks/main.yml
@@ -3,7 +3,7 @@
     name: "{{ mgmt_ip }}"
     state: absent
   delegate_to: localhost
-  no_log: "{{ lookup('env', 'METROAE_NO_LOG') or 'true' }}"
+  no_log: True
   ignore_errors: True
 
 - name: Check VSD Health after deployment

--- a/src/roles/vsd-upgrade-postdeploy/tasks/main.yml
+++ b/src/roles/vsd-upgrade-postdeploy/tasks/main.yml
@@ -36,7 +36,7 @@
   delegate_to: localhost
   run_once: true
   when: groups['vscs'] is defined and groups['vscs'][0] is defined
-  no_log: "{{ lookup('env', 'METROAE_NO_LOG') or 'true' }}"
+  no_log: True
   ignore_errors: True
 
 - name: Clean known_hosts of VSC 2 on "{{ target_server }}" (ignoring errors)
@@ -46,7 +46,7 @@
   delegate_to: localhost
   run_once: true
   when: groups['vscs'] is defined and groups['vscs'][1] is defined
-  no_log: "{{ lookup('env', 'METROAE_NO_LOG') or 'true' }}"
+  no_log: True
   ignore_errors: True
 
 - name: Shut/noshut vswitch controller on vsc1 after disabling VSD maintenance mode

--- a/src/roles/vsd-vns-postdeploy/tasks/main.yml
+++ b/src/roles/vsd-vns-postdeploy/tasks/main.yml
@@ -3,7 +3,7 @@
     name: "{{ mgmt_ip }}"
     state: absent
   delegate_to: localhost
-  no_log: "{{ lookup('env', 'METROAE_NO_LOG') or 'true' }}"
+  no_log: True
   ignore_errors: True
 
 - name: Verify if VSD TLS mode is set to allow

--- a/src/roles/vsr-deploy/tasks/main.yml
+++ b/src/roles/vsr-deploy/tasks/main.yml
@@ -3,7 +3,7 @@
     name: "{{ mgmt_ip }}"
     state: absent
   delegate_to: localhost
-  no_log: "{{ lookup('env', 'METROAE_NO_LOG') or 'true' }}"
+  no_log: True
   ignore_errors: True
 
 - name: run show version on remote devices

--- a/src/roles/vsr-postdeploy/tasks/main.yml
+++ b/src/roles/vsr-postdeploy/tasks/main.yml
@@ -3,7 +3,7 @@
     name: "{{ mgmt_ip }}"
     state: absent
   delegate_to: localhost
-  no_log: "{{ lookup('env', 'METROAE_NO_LOG') or 'true' }}"
+  no_log: True
   ignore_errors: True
 
 - name: Copy Python python scripts

--- a/src/roles/vstat-deploy/tasks/main.yml
+++ b/src/roles/vstat-deploy/tasks/main.yml
@@ -3,7 +3,7 @@
     name: "{{ mgmt_ip }}"
     state: absent
   delegate_to: localhost
-  no_log: "{{ lookup('env', 'METROAE_NO_LOG') or 'true' }}"
+  no_log: True
   ignore_errors: True
 
 - name: Wait for VSTAT ssh to be ready

--- a/src/roles/vstat-health/tasks/main.yml
+++ b/src/roles/vstat-health/tasks/main.yml
@@ -3,7 +3,7 @@
     name: "{{ mgmt_ip }}"
     state: absent
   delegate_to: localhost
-  no_log: "{{ lookup('env', 'METROAE_NO_LOG') or 'true' }}"
+  no_log: True
   ignore_errors: True
 
 - import_tasks: report_header.yml

--- a/src/roles/vstat-postdeploy/tasks/main.yml
+++ b/src/roles/vstat-postdeploy/tasks/main.yml
@@ -3,7 +3,7 @@
     name: "{{ mgmt_ip }}"
     state: absent
   delegate_to: localhost
-  no_log: "{{ lookup('env', 'METROAE_NO_LOG') or 'true' }}"
+  no_log: True
   ignore_errors: True
 
 - name: Stat the pid file for elasticsearch process

--- a/src/roles/vstat-predeploy/tasks/main.yml
+++ b/src/roles/vstat-predeploy/tasks/main.yml
@@ -67,7 +67,7 @@
       name: "{{ mgmt_ip }}"
       state: absent
     delegate_to: localhost
-    no_log: "{{ lookup('env', 'METROAE_NO_LOG') or 'true' }}"
+    no_log: True
     ignore_errors: True
 
   - name: Wait for VSTAT ssh to be ready

--- a/src/roles/vstat-vsd-health/tasks/main.yml
+++ b/src/roles/vstat-vsd-health/tasks/main.yml
@@ -5,7 +5,7 @@
       name: "{{ mgmt_ip }}"
       state: absent
     delegate_to: localhost
-    no_log: "{{ lookup('env', 'METROAE_NO_LOG') or 'true' }}"
+    no_log: True
     ignore_errors: True
 
   - name: Wait for ES VSD processes to become running


### PR DESCRIPTION
The known_hosts calls can dump megabytes of irrelevant nonsense to the logs and it is never useful.  Forcing no_log on these to prevent the spam.