### PR TITLE
Fix /etc/hosts restore on custom username on upgrade

### DIFF
--- a/src/playbooks/with_build/vsd_upgrade_complete.yml
+++ b/src/playbooks/with_build/vsd_upgrade_complete.yml
@@ -1,10 +1,6 @@
 ---
 - hosts: primary_vsds
   gather_facts: no
-  remote_user: "{{ vsd_custom_username | default(vsd_default_username) }}"
-  become: "{{ 'no' if vsd_custom_username | default(vsd_default_username) == 'root' else 'yes' }}"
-  vars:
-    ansible_become_pass: "{{ vsd_custom_password | default(vsd_default_password) }}"
   tasks:
     - name: Restore /etc/hosts files on VSD after upgrade
       include_role:

--- a/src/roles/vsd-restore-hostfile/tasks/main.yml
+++ b/src/roles/vsd-restore-hostfile/tasks/main.yml
@@ -5,7 +5,4 @@
     mode: 0644
     owner: "{{ vsd_default_username }}"
     group: "{{ vsd_default_username }}"
-  remote_user: "{{ vsd_custom_username | default(vsd_default_username) }}"
-  become: "{{ 'no' if vsd_custom_username | default(vsd_default_username) == 'root' else 'yes' }}"
-  vars:
-    ansible_become_pass: "{{ vsd_custom_password | default(vsd_default_password) }}"
+  remote_user: "{{ vsd_default_username }}"


### PR DESCRIPTION
Fix /etc/hosts restore on custom username on upgrade

-- Do not need custom username as upgraded VM has default username