### PR TITLE
Adding support for symlinks as files

### DIFF
--- a/src/roles/common/tasks/find-file.yml
+++ b/src/roles/common/tasks/find-file.yml
@@ -1,6 +1,7 @@
 
 - name: "Search for {{ pattern }} File"
   find:
+    file_type: any
     path: "{{ dir_name | default(nuage_unzipped_files_dir) }}"
     patterns: "{{ pattern }}"
     recurse: yes


### PR DESCRIPTION
Adding support for finding symlinks, which is very useful in setups where people have access to file repositories but can not change the file structure and do not want to copy all the files