### PR TITLE
Adding support for checking the size on the right vCenter datastore if one is provided

### DIFF
--- a/src/roles/common/tasks/check-predeploy-prereq.yml
+++ b/src/roles/common/tasks/check-predeploy-prereq.yml
@@ -75,9 +75,18 @@
       datacenter: "{{ vcenter.datacenter }}"
     register: datastore_facts
 
+  - name: Select first datastore by default
+    set_fact:
+      vmware_datastore: "{{ datastore_facts.datastores | first }}"
+
+  - name: Select correct datastore
+    set_fact:
+      vmware_datastore: "{{ (datastore_facts.datastores | selectattr('name','equalto',vcenter.datastore) | first) }}"
+    when: vcenter.datastore is defined
+
   - name: Set fact for datastore free space
     set_fact:
-      datastore_free_space_kb: "{{ datastore_facts['datastores'][0].freeSpace | float / 1024 }}"
+      datastore_free_space_kb: "{{ vmware_datastore.freeSpace | float / 1024 }}"
 
   - name: Set fact for required available disk space
     set_fact:


### PR DESCRIPTION
When there are multiple datastores available in vCenter, it would only check the first datastore for the necessary space required. If the user provides their own datastore (`vcenter.datastore`), it is that datastore that should be checked instead. 