### PR TITLE
vnsutil-predeploy folder variable correction

### DIFF
--- a/src/roles/vnsutil-predeploy/tasks/vcenter.yml
+++ b/src/roles/vnsutil-predeploy/tasks/vcenter.yml
@@ -36,7 +36,7 @@
       password: "{{ vcenter.password }}"
       name: "{{ vm_name }}"
       datacenter: "{{ vcenter.datacenter }}"
-      folder: "{{ vcenter.vm_folder | default(omit) }}"
+      folder: "{{ vcenter.vmfolder | default(omit) }}"
       validate_certs: no
     register: vnsutil_vm_facts
 


### PR DESCRIPTION
I checked that yesterday the scheduled task failed for vcenter at vns-utils deploy, I think it failed at the Waiting for VMware tools to be installed task, 
and I went back and checked that I did not update the new variable for vnsutils-predeploy task and that is why it was failing, so I have created a new PR for that, so
maybe you can review it and merge so that the issue might get resolved.  I am really sorry that I overlooked this part and just changed for vsd, vstat and vsc. 