### PR TITLE
Fix copying of external certs

### DIFF
--- a/src/roles/common/tasks/vsc-tls-setup.yml
+++ b/src/roles/common/tasks/vsc-tls-setup.yml
@@ -13,8 +13,8 @@
   - block:
     - name: Copy external certificates
       command: >-
-        "sshpass -p{{ vsc_default_password }} scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "
-        "{{ item }} {{ vsc_default_username }}@{{ mgmt_ip }}:/{{ item | basename }}"
+        sshpass -p{{ vsc_default_password }} scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null
+        {{ item }} {{ vsc_default_username }}@{{ mgmt_ip }}:/{{ item | basename }}
       no_log: "{{ lookup('env', 'METROAE_NO_LOG') or 'true' }}"
       with_items:
         - "{{ private_key_path }}"


### PR DESCRIPTION
Fixing the long line length for linting caused the command string to be incorrect.