### PR TITLE
Fixes for SDWAN Portal

### DIFF
--- a/Documentation/RELEASE_NOTES.md
+++ b/Documentation/RELEASE_NOTES.md
@@ -28,6 +28,7 @@
 * Allow VSC to be specified without system ip (METROAE-1413)
 * Added Serial=1 to prevent on VSD lockout of iptables during VSC's upgrade
 * Fixed static route gateway issue in VNSUTIL
+* Fixed issue with SDWAN Portal configuration (METROAE-244)
 
 
 ## Test Matrix

--- a/src/roles/sdwan-portal-deploy/templates/config.j2
+++ b/src/roles/sdwan-portal-deploy/templates/config.j2
@@ -1,4 +1,7 @@
 forgot.password.sender.address: {{ forgot_password_email }}
+advanced.client.timeout: '180'
+advanced.es.timeout: '60000'
+vnsportal.default.ui: 1
 gr.dc: '1'
 gr.dc1.address: 0.0.0.0
 gr.dc2.address: 0.0.0.0
@@ -22,10 +25,10 @@ proxy.enabled: false
 proxy.port: ''
 proxy.url: 0.0.0.0
 smtp.host: {{ smtp_fqdn | default('None') }}
-smtp.password: {{ smtp_password }}
-smtp.port: {{ smtp_port | default('None')  }}
-smtp.secureConnection: {{ smtp_secure | default('false') }}
-smtp.user: {{ smtp_port | default('25')  }}
+smtp.password: '{{ smtp_password }}'
+smtp.port: '{{ smtp_port | default('None') }}'
+smtp.secureConnection: {{ '1' if smtp_secure is defined and smtp_secure else '0' }}
+smtp.user: '{{ smtp_port | default('25') }}'
 spring.data.jest.uri: http://{{ vstat_fqdn_global }}
 sso.custom.entityId: com:nokia:vnsportal:sp
 sso.custom.idp.metadata: idp.metadata.xml


### PR DESCRIPTION
Fix for HAPROXY not working during sdwan portal setup.  It appears that the config.yml template for the portal has some incorrectly formatted fields.