### PR TITLE
SKipping VSD deploy if VSD is already installed

### DIFF
--- a/Documentation/RELEASE_NOTES.md
+++ b/Documentation/RELEASE_NOTES.md
@@ -17,6 +17,7 @@
 Enhance several license file descriptions to include the file name
 Updated SDWAN portal to support 20.11 version
 Force rebuild after missing files (METROAE-298) 
+VSD deploy no longer idempotent (METROAE-304)
 
 ## Test Matrix
 

--- a/Documentation/RELEASE_NOTES.md
+++ b/Documentation/RELEASE_NOTES.md
@@ -17,7 +17,7 @@
 Enhance several license file descriptions to include the file name
 Updated SDWAN portal to support 20.11 version
 Force rebuild after missing files (METROAE-298) 
-VSD deploy no longer idempotent (METROAE-304)
+Fixed VSD deploy task to be idempotent (METROAE-304)
 
 ## Test Matrix
 

--- a/src/roles/vsd-deploy/tasks/main.yml
+++ b/src/roles/vsd-deploy/tasks/main.yml
@@ -154,6 +154,7 @@
 
 - name: Renew VSD ejabberd license
   import_tasks: renew_ejabberd_license.yml
+  when: not skip_vsd_deploy
 
 - block:
 
@@ -373,7 +374,7 @@
       debug: var=vsd_proc verbosity=1
 
     when: monit_mail_server is defined
-
+  when: not skip_vsd_deploy
   remote_user: "{{ vsd_default_username }}"
 
 - import_tasks: brand_vsd.yml

--- a/src/roles/vsd-deploy/tasks/main.yml
+++ b/src/roles/vsd-deploy/tasks/main.yml
@@ -374,6 +374,7 @@
       debug: var=vsd_proc verbosity=1
 
     when: monit_mail_server is defined
+  
   when: not skip_vsd_deploy
   remote_user: "{{ vsd_default_username }}"
 


### PR DESCRIPTION
- Changes
  - Added `skip_vsd_deploy` check to avoid the vsd deploy.