### PR TITLE
Hide log output in vsd-node-info

### DIFF
--- a/Documentation/RELEASE_NOTES.md
+++ b/Documentation/RELEASE_NOTES.md
@@ -29,6 +29,7 @@
 * Add option to override VSC config (METROAE-314)
 * Fix DNS dns_mgmt and dns_data to relax requirement of having specific length. (METROAE-315)
 * Add vstat-health role to vstat_health playbook (METROAE-322)
+* Hide log output in vsd-node-info (METROAE-332)
 * Remove vstat-vsd-health role from vstat_health playbook (METROAE-322)
 
 ## Test Matrix

--- a/src/roles/common/tasks/vsd-node-info.yml
+++ b/src/roles/common/tasks/vsd-node-info.yml
@@ -33,6 +33,7 @@
     set_fact:
       custom_username: "{{ hostvars[groups['vsd_ha_node1'][0]].vsd_custom_username | default(vsd_custom_username) }}"
       custom_password: "{{ hostvars[groups['vsd_ha_node1'][0]].vsd_custom_password | default(vsd_custom_password) }}"
+    no_log: "{{ lookup('env', 'METROAE_NO_LOG') or 'true' }}"
     when:
       - hostvars[groups['vsd_ha_node1'][0]].vsd_custom_username is defined or vsd_custom_username is defined
 


### PR DESCRIPTION
Hide log output in vsd-node-info (METROAE-332)