### PR TITLE
Replacing known_hosts module mgmt_ip to hostname

### DIFF
--- a/src/roles/vstat-deploy/tasks/main.yml
+++ b/src/roles/vstat-deploy/tasks/main.yml
@@ -1,6 +1,6 @@
 - name: Clean known_hosts of VSTATs (ignoring errors)
   known_hosts:
-    name: "{{ mgmt_ip }}"
+    name: "{{ hostname }}"
     state: absent
   delegate_to: localhost
   no_log: True


### PR DESCRIPTION
hostname is used in vsd-deploy but not in vstat-deploy