### PR TITLE
Deploy NUH optionally without DNS server

### DIFF
--- a/Documentation/RELEASE_NOTES.md
+++ b/Documentation/RELEASE_NOTES.md
@@ -31,6 +31,7 @@
 * Added ES servers to NUH GUI ( METROAE-491)
 * Fix NUH install on 20.10.R5 (METROAE-490)
 * Fixing message issue for docker pull(METROAE-527)
+* Install NUH optionally without DNS entry (METROAE-375)
 * Add procedure for NUH copy certificates if installed before VSD(METROAE-559)
 
 ## Test Matrix

--- a/schemas/common.json
+++ b/schemas/common.json
@@ -125,7 +125,6 @@
             "title": "DNS server IP(s)",
             "description": "List of one or more DNS server addresses for resolving component domain names. Must be in dotted-decimal (IPv4) or hexidecimal (IPv6) format.",
             "sectionEnd": "Network Services",
-            "minItems": 1,
             "propertyOrder": 150,
             "items": {
                 "type": "string",

--- a/src/roles/nuh-predeploy/templates/ifcfg-eth0.j2
+++ b/src/roles/nuh-predeploy/templates/ifcfg-eth0.j2
@@ -13,7 +13,9 @@ NM_CONTROLLED="no"
 ONBOOT="yes"
 TYPE="Ethernet"
 BOOTPROTO="static"
+{% if dns_server_list is defined and dns_server_list %}
 DNS1="{{dns_server_list[0]}}"
+{% endif %}
 {% if dns_server_list[1] is defined %}
 DNS2="{{dns_server_list[1]}}"
 {% endif %}


### PR DESCRIPTION
Install NUH optionally without DNS entry (METROAE-375)