### PR TITLE
Change Ansible version check for Ansible 3

### DIFF
--- a/src/playbooks/build.yml
+++ b/src/playbooks/build.yml
@@ -1,17 +1,31 @@
 ---
 - hosts: localhost
   pre_tasks:
-    - name: Check for Ansible version
+    - name: Get Ansible version
+      shell:
+        cmd: pip3 freeze | grep -w ansible
+      register: ansible_info
+
+    - name: Extract Ansible version from output
+      set_fact:
+        version_ansible: "{{ ansible_info.stdout | regex_search('[^=].\\d.+\\d') }}"
+
+    - name: Check Ansible version
       assert:
-        that: "ansible_version.full is version('3.4.0', operator='ge', strict=True)"
-        msg: "Ansible version must be greater than or equal to 3.4.0. Found Ansible version {{ansible_version.full}}"
+        that: "version_ansible is version('3.4.0', operator='ge', strict=True)"
+        msg: "Ansible version must be greater than or equal to 3.4.0. Found Ansible version {{ version_ansible }}"
+
+    - name: Check Ansible base version
+      assert:
+        that: "ansible_version.full is version('2.10.15', operator='ge', strict=True)"
+        msg: "Ansible base version must be greater than or equal to 2.10.15. Found Ansible base version {{ ansible_version.full }}"
 
     - name: Get Paramiko version
       shell:
         cmd: pip3 freeze | grep paramiko
       register: paramiko_info
 
-    - name: Extract version from output
+    - name: Extract Paramiko version from output
       set_fact:
         paramiko_version: "{{ paramiko_info.stdout | regex_search('[^=].\\d.+\\d') }}"
 


### PR DESCRIPTION
The ansible_version dictionary only contains data for ansible-base (added in Ansible 2.10, which Ansible 3 is based on). Ansible-base 2.10.15 is installed with Ansible 3.4.0 (we may need to hammer that down - or we could eliminate the ansible-base check altogether and just check if ansible version is 3.4.0 or newer)