### PR TITLE
Fix NSGv deploy with no ZFB

### DIFF
--- a/Documentation/RELEASE_NOTES.md
+++ b/Documentation/RELEASE_NOTES.md
@@ -3,7 +3,7 @@
 ## Release info
 
 * MetroAE Version 5.1.0
-* Nuage Release Alignment 
+* Nuage Release Alignment
 * Date of Release TBD
 
 ## Release Contents
@@ -20,6 +20,7 @@
 * Allow for a custom config file during VSC Upgrade (METROAE-485)
 * NUH changes for stats-out (METROAE-620)
 * Updated deprecated settings in ansible.cfg (METROAE-602)
+* Fix NSGv deployment when bootstrap method is None
 
 ## Test Matrix
 

--- a/src/roles/common/templates/nsgv.j2
+++ b/src/roles/common/templates/nsgv.j2
@@ -50,7 +50,7 @@ access_bridges:
 
 bootstrap_method: {{ item.bootstrap_method | default('none') }}
 
-{% if item.bootstrap_method is not match ("zfb_metro") %}
+{% if item.bootstrap_method | default('none') is match('zfb_external') %}
 iso_path: {{ item.iso_path }}
 iso_file: {{ item.iso_file }}
 {% endif %}
@@ -124,9 +124,9 @@ zfb_ports:
 {% for port in nsgv_network_port_vlans %}
 {% if port.name in item.network_port_vlans %}
             - vlan_value: {{ port.vlan_number }}
-              uplink: {{port.uplink | default(False) }} 
-              vsc_infra_profile_name: {{port.vsc_infra_profile_name }} 
-              firstController: {{port.first_controller_address }} 
+              uplink: {{port.uplink | default(False) }}
+              vsc_infra_profile_name: {{port.vsc_infra_profile_name }}
+              firstController: {{port.first_controller_address }}
 {% if item.second_controller_address is defined or nsgv_bootstrap.second_controller_address is defined %}
               secondController: {{ item.second_controller_address | default(nsgv_bootstrap.second_controller_address) }}
 {% endif %}


### PR DESCRIPTION
Marc Wolf ran into an issue trying to deploy NSGv with bootstrap_method set to none. He had to define the iso_path and iso_file because our template checks to see if those are defined if bootstrap_method is set to anything other than zfb_metro. However, the only bootstrap method that requires the iso path and file to be defined is zfb_external. 