### PR TITLE
NTP message is refering to wrong name of ntpd daemon

### DIFF
--- a/src/roles/common/tasks/linux-ntp-sync.yml
+++ b/src/roles/common/tasks/linux-ntp-sync.yml
@@ -56,7 +56,7 @@
     fail:
       msg: >-
        There seems to be an issue connecting to the specified NTP servers.
-       Please verify the IP addresses and check "systemctl status ntpdate.service" and "journalctl -xe" for further details.
+       Please verify the IP addresses and check "systemctl status ntpd.service" and "journalctl -xe" for further details.
     when:
       - ntpdate_status.msg is defined
       - ntpdate_status.msg is search('ntpdate.service failed')


### PR DESCRIPTION
The NTP message is refering to wrong name of ntpd daemon. 
updated  "systemctl status ntpdate.service" to "systemctl status ntpd.service"