### PR TITLE
metroae-662

### DIFF
--- a/docker/build-container
+++ b/docker/build-container
@@ -6,9 +6,17 @@ if [[ -n "$HTTP_PROXY" ]]
 then
     export buildproxy="--build-arg http_proxy=$HTTP_PROXY"
 fi
+if [[ -n "$http_proxy" ]]
+then
+    export buildproxy="--build-arg http_proxy=$http_proxy"
+fi
 if [[ -n "$HTTPS_PROXY" ]]
 then
     export buildproxy="$buildproxy --build-arg https_proxy=$HTTPS_PROXY"
+fi
+if [[ -n "$https_proxy" ]]
+then
+    export buildproxy="$buildproxy --build-arg https_proxy=$https_proxy"
 fi
 
 cp -f ../yum_requirements.txt ./


### PR DESCRIPTION
The code here is to make metro support proxy information provided with http_proxy and not just HTTP_PROXY, and https_proxy and not just HTTPS_PROXY. 

