### PR TITLE
metroae-662

### DIFF
--- a/Documentation/RELEASE_NOTES.md
+++ b/Documentation/RELEASE_NOTES.md
@@ -2,23 +2,17 @@
 
 ## Release info
 
-* MetroAE Version 5.3.0
+* MetroAE Version 5.4.0
 * Nuage Release Alignment 20.10.R1
-* Date of Release 05-September-2022
+* Date of Release 
 
 ## Release Contents
 
 ### Feature Enhancements
-* Add support for VSD upgrade to 20.10.R9 (METROAE-652)
-* Add support for VSTAT(ES) upgrade to 20.10.R8 (METROAE-659)
-* Allow users to shut down VMs (METROAE-629)
-* Add support for VSC CPU, memory  health check (METROAE-657) 
-* Enhance VSD health check report for CPU and memory (METROAE-656)
+* Add lowercase proxy env support (METROAE-662)
 
 ### Resolved Issues
-* Update Documentation about SELinux and supported components (METROAE-660)
-* Investigate stats-out ES Upgrade from 20.10.R5 to 20.10.R7 (METROAE-608)
-* Fixed package 'Six' issue (METROAE-658)
+
 
 ## Test Matrix
 

--- a/docker/build-container
+++ b/docker/build-container
@@ -6,9 +6,17 @@ if [[ -n "$HTTP_PROXY" ]]
 then
     export buildproxy="--build-arg http_proxy=$HTTP_PROXY"
 fi
+if [[ -n "$http_proxy" ]]
+then
+    export buildproxy="--build-arg http_proxy=$http_proxy"
+fi
 if [[ -n "$HTTPS_PROXY" ]]
 then
     export buildproxy="$buildproxy --build-arg https_proxy=$HTTPS_PROXY"
+fi
+if [[ -n "$https_proxy" ]]
+then
+    export buildproxy="$buildproxy --build-arg https_proxy=$https_proxy"
 fi
 
 cp -f ../yum_requirements.txt ./


### PR DESCRIPTION
The code here is to make metro support proxy information provided with http_proxy and not just HTTP_PROXY, and https_proxy and not just HTTPS_PROXY.